### PR TITLE
Support for AR and IP update transactions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ A complete setup consists of ([diagram](https://docs.google.com/drawings/d/1FWV8
 #### Local setup
 
 Detailed instructions on setting up a local node/baker are given in the readme of
-the [p2p-client](https://gitlab.com/Concordium/p2p-client).
+the [concordium-node](https://github.com/Concordium/concordium-node/tree/main/concordium-node) repository.
 
 The easiest solution is to start a local cluster using the docker-compose scripts in the root of that repo.
 This will start all components except for the middleware. The scripts support multiple different cluster sizes;
@@ -79,7 +79,7 @@ to spin up 5 nodes, use:
 EXTRA_ARGS=--debug NUM_BAKERS=5 DESIRED_PEERS=4 docker-compose -f docker-compose.develop.yml up --scale baker=5 --force-recreate
 ```
 
-The middleware lives in the [simple-client](https://gitlab.com/Concordium/consensus/simple-client/) repo
+The middleware lives in the [concordium-client](https://github.com/Concordium/concordium-client) repo
 and may be started (from the root of that project) using the command
 ```
 NODE_URL=127.0.0.1:$PORT stack run middleware
@@ -88,9 +88,9 @@ where `$PORT` is the GRPC port of the node (default: 10000).
 
 If the docker-compose scripts are used, then `scripts/bootMiddleware.sh` will run the above command with a working port.
 
-The node and [collector](https://gitlab.com/Concordium/p2p-client/blob/develop/src/bin/collector.rs)
-([backend](https://gitlab.com/Concordium/p2p-client/blob/develop/src/bin/collector_backend.rs)) is defined in the
-[p2p-client](https://gitlab.com/Concordium/p2p-client) repo.
+The node and [collector](https://github.com/Concordium/concordium-node/blob/main/concordium-node/src/bin/collector.rs)
+([backend](https://github.com/Concordium/concordium-node/blob/main/concordium-node/src/bin/collector_backend.rs)) is defined in the
+[concordium-node](https://github.com/Concordium/concordium-node/tree/main/concordium-node) repo.
 
 Note that you need to set a feature flag to build the collector (backend).
 

--- a/elm.json
+++ b/elm.json
@@ -16,6 +16,7 @@
             "elm/html": "1.0.0",
             "elm/http": "2.0.0",
             "elm/json": "1.1.3",
+            "elm/regex": "1.0.0",
             "elm/svg": "1.0.1",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
@@ -46,7 +47,6 @@
         "indirect": {
             "elm/bytes": "1.0.8",
             "elm/parser": "1.1.0",
-            "elm/regex": "1.0.0",
             "elm/virtual-dom": "1.0.2",
             "folkertdev/elm-deque": "3.0.1",
             "folkertdev/one-true-path-experiment": "5.0.2",

--- a/src/client/elm/Explorer/Request.elm
+++ b/src/client/elm/Explorer/Request.elm
@@ -97,6 +97,8 @@ type alias UpdateQueues =
     , electionDifficulty : UpdateQueue Float
     , euroPerEnergy : UpdateQueue Relation
     , bakerStakeThreshold : UpdateQueue T.Amount
+    , anonymityRevoker: UpdateQueue AnonymityRevokerInfo
+    , identityProvider: UpdateQueue IdentityProviderInfo
     }
 
 
@@ -156,7 +158,8 @@ updateQueuesDecoder =
         |> required "electionDifficulty" (updateQueueDecoder D.float)
         |> required "euroPerEnergy" (updateQueueDecoder relationDecoder)
         |> required "bakerStakeThreshold" (updateQueueDecoder T.decodeAmount)
-
+        |> required "addAnonymityRevoker" (updateQueueDecoder arDecoder)
+        |> required "addIdentityProvider" (updateQueueDecoder ipDecoder)
 
 updateQueueDecoder : D.Decoder a -> D.Decoder (UpdateQueue a)
 updateQueueDecoder decoder =

--- a/src/client/elm/Explorer/View.elm
+++ b/src/client/elm/Explorer/View.elm
@@ -949,8 +949,8 @@ listUpdatePayloads queues =
         ++ mapUpdate EuroPerEnergyPayload queues.euroPerEnergy
         ++ mapUpdate MintDistributionPayload queues.mintDistribution
         ++ mapUpdate BakerStakeThresholdPayload queues.bakerStakeThreshold
-        ++ mapUpdate UpdateAddAnonymityRevokerPayload queues.anonymityRevoker
-        ++ mapUpdate UpdateAddIdentityProviderPayload queues.identityProvider
+        ++ mapUpdate AddAnonymityRevokerPayload queues.anonymityRevoker
+        ++ mapUpdate AddIdentityProviderPayload queues.identityProvider
 
 
 asPercentage : Float -> String
@@ -1867,10 +1867,10 @@ viewEventUpdateEnqueuedDetails ctx event =
         BakerStakeThresholdPayload threshold ->
             paragraph [] [ text <| "Update the minimum staked amount for becoming a baker to " ++ T.amountToString threshold ]
 
-        UpdateAddAnonymityRevokerPayload (ArInfo anonymityRevokerInfo) ->
+        AddAnonymityRevokerPayload (ArInfo anonymityRevokerInfo) ->
             paragraph [] <| text ("Add a new anonymity revoker. ") :: displayArIp anonymityRevokerInfo
 
-        UpdateAddIdentityProviderPayload (IpInfo identityProviderInfo) ->
+        AddIdentityProviderPayload (IpInfo identityProviderInfo) ->
             paragraph [] <| text ("Add a new identity provider. ") :: displayArIp identityProviderInfo
 
 

--- a/src/client/elm/Explorer/View.elm
+++ b/src/client/elm/Explorer/View.elm
@@ -1867,25 +1867,25 @@ viewEventUpdateEnqueuedDetails ctx event =
         BakerStakeThresholdPayload threshold ->
             paragraph [] [ text <| "Update the minimum staked amount for becoming a baker to " ++ T.amountToString threshold ]
 
-        UpdateAddAnonymityRevokerPayload anonymityRevokerInfo ->
-            paragraph [] [ text <| "Add a new anonymity revoker. " ++ displayAnonymityRevoker anonymityRevokerInfo]
+        UpdateAddAnonymityRevokerPayload (ArInfo anonymityRevokerInfo) ->
+            paragraph [] <| text ("Add a new anonymity revoker. ") :: displayArIp anonymityRevokerInfo
 
-        UpdateAddIdentityProviderPayload identityProviderInfo ->
-            paragraph [] [ text <| "Add a new identity provider\n" ++ displayIdentityProvider identityProviderInfo]
-
-
-displayAnonymityRevoker : AnonymityRevokerInfo -> String
-displayAnonymityRevoker arInfo = "Name: " ++ arInfo.arDescription.name
-    ++ ". Identity: " ++ String.fromInt arInfo.arIdentity
-    ++ ". Description: " ++ arInfo.arDescription.description
-    ++ ". URL: " ++ arInfo.arDescription.url
+        UpdateAddIdentityProviderPayload (IpInfo identityProviderInfo) ->
+            paragraph [] <| text ("Add a new identity provider. ") :: displayArIp identityProviderInfo
 
 
-displayIdentityProvider : IdentityProviderInfo -> String
-displayIdentityProvider ipInfo = "Name: " ++ ipInfo.ipDescription.name
-    ++ ". Identity: " ++ String.fromInt ipInfo.ipIdentity
-    ++ ". Description: " ++ ipInfo.ipDescription.description
-    ++ ". URL: " ++ ipInfo.ipDescription.url
+displayArIp : ArIpInfo -> List (Element Msg)
+displayArIp info =
+    let descr = info.description
+    in [ text <| "Name: " ++ descr.name
+                 ++ ". Identity: " ++ String.fromInt info.identity
+                 ++ ". Description: " ++ descr.description
+                 ++ ". "
+       , link [ onClick <| UrlClicked <| Browser.External descr.url ]
+              { url = descr.url
+              , label = el [ Font.underline ] <| text descr.url
+              }
+       ]
 
 
 {-| Display a relation as a fraction

--- a/src/client/elm/Explorer/View.elm
+++ b/src/client/elm/Explorer/View.elm
@@ -949,6 +949,8 @@ listUpdatePayloads queues =
         ++ mapUpdate EuroPerEnergyPayload queues.euroPerEnergy
         ++ mapUpdate MintDistributionPayload queues.mintDistribution
         ++ mapUpdate BakerStakeThresholdPayload queues.bakerStakeThreshold
+        ++ mapUpdate UpdateAddAnonymityRevokerPayload queues.anonymityRevoker
+        ++ mapUpdate UpdateAddIdentityProviderPayload queues.identityProvider
 
 
 asPercentage : Float -> String
@@ -1864,6 +1866,26 @@ viewEventUpdateEnqueuedDetails ctx event =
 
         BakerStakeThresholdPayload threshold ->
             paragraph [] [ text <| "Update the minimum staked amount for becoming a baker to " ++ T.amountToString threshold ]
+
+        UpdateAddAnonymityRevokerPayload anonymityRevokerInfo ->
+            paragraph [] [ text <| "Add a new anonymity revoker. " ++ displayAnonymityRevoker anonymityRevokerInfo]
+
+        UpdateAddIdentityProviderPayload identityProviderInfo ->
+            paragraph [] [ text <| "Add a new identity provider\n" ++ displayIdentityProvider identityProviderInfo]
+
+
+displayAnonymityRevoker : AnonymityRevokerInfo -> String
+displayAnonymityRevoker arInfo = "Name: " ++ arInfo.arDescription.name
+    ++ ". Identity: " ++ String.fromInt arInfo.arIdentity
+    ++ ". Description: " ++ arInfo.arDescription.description
+    ++ ". URL: " ++ arInfo.arDescription.url
+
+
+displayIdentityProvider : IdentityProviderInfo -> String
+displayIdentityProvider ipInfo = "Name: " ++ ipInfo.ipDescription.name
+    ++ ". Identity: " ++ String.fromInt ipInfo.ipIdentity
+    ++ ". Description: " ++ ipInfo.ipDescription.description
+    ++ ". URL: " ++ ipInfo.ipDescription.url
 
 
 {-| Display a relation as a fraction

--- a/src/client/elm/Explorer/View.elm
+++ b/src/client/elm/Explorer/View.elm
@@ -886,7 +886,7 @@ viewUpdates theme updates =
                         TimeHelpers.formatTime Time.utc <|
                             update.effectiveTime
                 )
-                (viewEventUpdateEnueuedDetails theme update)
+                (viewEventUpdateEnqueuedDetails theme update)
     in
     if List.isEmpty allQueuedUpdates then
         column [ width fill, padding 20 ] [ el [ centerX, Font.color theme.palette.fg2 ] <| text "No updates queued at the time of this block." ]
@@ -1746,7 +1746,7 @@ viewTransactionEvent ctx txEvent =
             , details =
                 Just <|
                     el [ padding 20 ] <|
-                        viewEventUpdateEnueuedDetails ctx event
+                        viewEventUpdateEnqueuedDetails ctx event
             }
 
         TransactionEventDataRegistered event ->
@@ -1764,8 +1764,8 @@ viewTransactionEvent ctx txEvent =
             }
 
 
-viewEventUpdateEnueuedDetails : Theme a -> EventUpdateEnqueued -> Element Msg
-viewEventUpdateEnueuedDetails ctx event =
+viewEventUpdateEnqueuedDetails : Theme a -> EventUpdateEnqueued -> Element Msg
+viewEventUpdateEnqueuedDetails ctx event =
     case event.payload of
         MintDistributionPayload mintDistribution ->
             let

--- a/src/client/elm/Explorer/View.elm
+++ b/src/client/elm/Explorer/View.elm
@@ -1903,7 +1903,8 @@ displayStr: String -> String -> Element Msg
 displayStr attrName str = let elem s = text <| attrName ++ ": " ++ s ++ ". "
                           in case Regex.fromString "[\\. ]*$" of -- to remove trailing spaces and periods
                                Nothing -> elem (String.trim str)
-                               Just regex -> elem <| Regex.replace regex (\_ -> "") str
+                               Just regex -> let trimmed = Regex.replace regex (\_ -> "") str
+                                             in if trimmed == "" then text "" else elem trimmed
 
 
 displayWebsite : String -> List (Element Msg)

--- a/src/client/elm/Explorer/View.elm
+++ b/src/client/elm/Explorer/View.elm
@@ -1888,8 +1888,11 @@ displayName: String -> Element Msg
 displayName = displayStr "Name"
 
 
-displayIdentity: Int -> Element Msg
-displayIdentity = displayStr "Identity" << String.fromInt
+displayIdentity: Identity -> Element Msg
+displayIdentity id = let i = case id of
+                             ArIdentity ar -> ar
+                             IpIdentity ip -> ip
+                     in displayStr "Identity" <| String.fromInt i
 
 
 displayDescription: String -> Element Msg

--- a/src/client/elm/Transaction/Event.elm
+++ b/src/client/elm/Transaction/Event.elm
@@ -219,8 +219,8 @@ type UpdatePayload
     | Level2KeysUpdatePayload Authorizations
     | ProtocolUpdatePayload ProtocolUpdate
     | BakerStakeThresholdPayload T.Amount
-    | UpdateAddAnonymityRevokerPayload AnonymityRevokerInfo
-    | UpdateAddIdentityProviderPayload IdentityProviderInfo
+    | AddAnonymityRevokerPayload AnonymityRevokerInfo
+    | AddIdentityProviderPayload IdentityProviderInfo
 
 
 type alias MintDistribution =
@@ -303,22 +303,26 @@ type alias Description =
     }
 
 
--- Identification number of an anonymity revoker or identity provider
+{-| Identification number of an anonymity revoker or identity provider
+-}
 type alias ArIpIdentity =
     Int
 
 
--- Information about anonymity revokers or identity providers
+{-| Information about anonymity revokers or identity providers
+-}
 type alias ArIpInfo =
     { identity: ArIpIdentity
     , description: Description
     }
 
--- Data for an anonymity revoker
+{-| Data for an anonymity revoker
+-}
 type AnonymityRevokerInfo = ArInfo ArIpInfo
 
 
--- Data for an identity provider
+{-| Data for an identity provider
+-}
 type IdentityProviderInfo = IpInfo ArIpInfo
 
 
@@ -378,10 +382,10 @@ updatePayloadDecoder =
                         T.decodeAmount |> D.map BakerStakeThresholdPayload
 
                     "addAnonymityRevoker" ->
-                        arDecoder |> D.map UpdateAddAnonymityRevokerPayload
+                        arDecoder |> D.map AddAnonymityRevokerPayload
 
                     "addIdentityProvider" ->
-                        ipDecoder |> D.map UpdateAddIdentityProviderPayload
+                        ipDecoder |> D.map AddIdentityProviderPayload
 
                     _ ->
                         D.fail "Unknown update type"

--- a/src/client/elm/Transaction/Event.elm
+++ b/src/client/elm/Transaction/Event.elm
@@ -305,14 +305,14 @@ type alias Description =
 
 {-| Identification number of an anonymity revoker or identity provider
 -}
-type alias ArIpIdentity =
-    Int
-
+type Identity
+    = ArIdentity Int
+    | IpIdentity Int
 
 {-| Information about anonymity revokers or identity providers
 -}
 type alias ArIpInfo =
-    { identity: ArIpIdentity
+    { identity: Identity
     , description: Description
     }
 
@@ -420,9 +420,13 @@ gasRewardsDecoder =
 arDecoder : D.Decoder AnonymityRevokerInfo
 arDecoder =
     let arIp = D.succeed ArIpInfo
-                |> required "arIdentity" D.int
+                |> required "arIdentity" arIdentityDecoder
                 |> required "arDescription" descriptionDecoder
     in D.map ArInfo arIp
+
+
+arIdentityDecoder : D.Decoder Identity
+arIdentityDecoder = D.map ArIdentity D.int
 
 
 descriptionDecoder : D.Decoder Description
@@ -436,9 +440,13 @@ descriptionDecoder =
 ipDecoder : D.Decoder IdentityProviderInfo
 ipDecoder =
     let arIp = D.succeed ArIpInfo
-                |> required "ipIdentity" D.int
+                |> required "ipIdentity" ipIdentityDecoder
                 |> required "ipDescription" descriptionDecoder
     in D.map IpInfo arIp
+
+
+ipIdentityDecoder : D.Decoder Identity
+ipIdentityDecoder = D.map IpIdentity D.int
 
 
 updateKeysCollectionDecoder : D.Decoder UpdateKeysCollection

--- a/src/client/elm/Transaction/Event.elm
+++ b/src/client/elm/Transaction/Event.elm
@@ -299,25 +299,27 @@ type alias ProtocolUpdate =
 type alias Description =
     { name: String
     , url: String
-    , description: String }
+    , description: String
+    }
 
 
-type alias ArIdentity =
+-- Identification number of an anonymity revoker or identity provider
+type alias ArIpIdentity =
     Int
 
 
-type alias AnonymityRevokerInfo =
-    { arIdentity: ArIdentity
-    , arDescription: Description }
+-- Information about anonymity revokers or identity providers
+type alias ArIpInfo =
+    { identity: ArIpIdentity
+    , description: Description
+    }
+
+-- Data for an anonymity revoker
+type AnonymityRevokerInfo = ArInfo ArIpInfo
 
 
-type alias IpIdentity =
-    Int
-
-
-type alias IdentityProviderInfo =
-    { ipIdentity: IpIdentity
-    , ipDescription: Description }
+-- Data for an identity provider
+type IdentityProviderInfo = IpInfo ArIpInfo
 
 
 -- Errors
@@ -413,9 +415,10 @@ gasRewardsDecoder =
 
 arDecoder : D.Decoder AnonymityRevokerInfo
 arDecoder =
-    D.succeed AnonymityRevokerInfo
-        |> required "arIdentity" D.int
-        |> required "arDescription" descriptionDecoder
+    let arIp = D.succeed ArIpInfo
+                |> required "arIdentity" D.int
+                |> required "arDescription" descriptionDecoder
+    in D.map ArInfo arIp
 
 
 descriptionDecoder : D.Decoder Description
@@ -428,9 +431,10 @@ descriptionDecoder =
 
 ipDecoder : D.Decoder IdentityProviderInfo
 ipDecoder =
-    D.succeed IdentityProviderInfo
-        |> required "ipIdentity" D.int
-        |> required "ipDescription" descriptionDecoder
+    let arIp = D.succeed ArIpInfo
+                |> required "ipIdentity" D.int
+                |> required "ipDescription" descriptionDecoder
+    in D.map IpInfo arIp
 
 
 updateKeysCollectionDecoder : D.Decoder UpdateKeysCollection

--- a/src/client/elm/Transaction/Event.elm
+++ b/src/client/elm/Transaction/Event.elm
@@ -219,6 +219,8 @@ type UpdatePayload
     | Level2KeysUpdatePayload Authorizations
     | ProtocolUpdatePayload ProtocolUpdate
     | BakerStakeThresholdPayload T.Amount
+    | UpdateAddAnonymityRevokerPayload AnonymityRevokerInfo
+    | UpdateAddIdentityProviderPayload IdentityProviderInfo
 
 
 type alias MintDistribution =
@@ -294,6 +296,29 @@ type alias ProtocolUpdate =
     }
 
 
+type alias Description =
+    { name: String
+    , url: String
+    , description: String }
+
+
+type alias ArIdentity =
+    Int
+
+
+type alias AnonymityRevokerInfo =
+    { arIdentity: ArIdentity
+    , arDescription: Description }
+
+
+type alias IpIdentity =
+    Int
+
+
+type alias IdentityProviderInfo =
+    { ipIdentity: IpIdentity
+    , ipDescription: Description }
+
 
 -- Errors
 
@@ -350,6 +375,12 @@ updatePayloadDecoder =
                     "bakerStakeThreshold" ->
                         T.decodeAmount |> D.map BakerStakeThresholdPayload
 
+                    "addAnonymityRevoker" ->
+                        arDecoder |> D.map UpdateAddAnonymityRevokerPayload
+
+                    "addIdentityProvider" ->
+                        ipDecoder |> D.map UpdateAddIdentityProviderPayload
+
                     _ ->
                         D.fail "Unknown update type"
     in
@@ -378,6 +409,28 @@ gasRewardsDecoder =
         |> required "accountCreation" D.float
         |> required "baker" D.float
         |> required "finalizationProof" D.float
+
+
+arDecoder : D.Decoder AnonymityRevokerInfo
+arDecoder =
+    D.succeed AnonymityRevokerInfo
+        |> required "arIdentity" D.int
+        |> required "arDescription" descriptionDecoder
+
+
+descriptionDecoder : D.Decoder Description
+descriptionDecoder =
+    D.succeed Description
+        |> required "name" D.string
+        |> required "url" D.string
+        |> required "description" D.string
+
+
+ipDecoder : D.Decoder IdentityProviderInfo
+ipDecoder =
+    D.succeed IdentityProviderInfo
+        |> required "ipIdentity" D.int
+        |> required "ipDescription" descriptionDecoder
 
 
 updateKeysCollectionDecoder : D.Decoder UpdateKeysCollection

--- a/src/client/elm/Transaction/Summary.elm
+++ b/src/client/elm/Transaction/Summary.elm
@@ -90,6 +90,10 @@ type UpdateType
     | UpdateTransactionFeeDistribution
       -- ^Update the distribution of transaction fees
     | UpdateGASRewards
+    | UpdateAddAnonymityRevoker
+      -- ^Add a new anonymity revoker
+    | UpdateAddIdentityProvider
+      -- ^Add a new identity provider
 
 
 type TransactionResult
@@ -317,6 +321,12 @@ updateTypeDecoder =
 
                     "updateGASRewards" ->
                         D.succeed UpdateGASRewards
+
+                    "updateAddAnonymityRevoker" ->
+                        D.succeed UpdateAddAnonymityRevoker
+
+                    "updateAddIdentityProvider" ->
+                        D.succeed UpdateAddIdentityProvider
 
                     _ ->
                         D.fail <| "Unknown UpdateType type: " ++ str

--- a/tests/Explorer/ViewTest.elm
+++ b/tests/Explorer/ViewTest.elm
@@ -1,0 +1,31 @@
+module Explorer.ViewTest exposing (..)
+
+import Expect exposing (Expectation, equalLists)
+import Test exposing (..)
+import Explorer.View exposing (displayStr)
+import Element exposing (..)
+
+suite : Test
+suite =
+    let actual = List.map (displayStr "Name") [ ""
+                                              , "..."
+                                              , "      .. .      ..    "
+                                              , "     "
+                                              , "a.  ..    .....  ."
+                                              , "..   ... a.  ..    .....  ."
+                                              , "..\n...   a... \n..  ..aa .."
+                                              , "\n\n\n"
+                                              ]
+        expected = List.map text [ ""
+                                 , ""
+                                 , ""
+                                 , ""
+                                 , "Name: a. "
+                                 , "Name: ..   ... a. "
+                                 , "Name: ..\n...   a... \n..  ..aa. "
+                                 , "Name: \n\n\n. "
+                                 ]
+    in describe "The Explorer.View module, displayStr function"
+        [ test "Displays update-transaction-description parts correctly" <|
+            \_ -> equalLists expected actual
+        ]


### PR DESCRIPTION
## Purpose

Displays two new update transaction types: for adding new anonymity revokers, and for adding new identity providers. This addresses #4.

## Changes

In addition to the above, updates README links to point from gitlab to github repositories, and fixes a typo in the `viewEventUpdateEnueuedDetails` function name.

Note: I'm adding this as a merge to `overflow-fix` (#6) to make it easier to review.

## Checklist

- [x] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.