### PR TITLE
Clarifying that insufficient funds refer to nonstaked funds.

### DIFF
--- a/src/client/elm/Explorer/View.elm
+++ b/src/client/elm/Explorer/View.elm
@@ -699,7 +699,14 @@ rejectionToItem ctx reason =
             }
 
         AmountTooLarge account amount ->
-            { content = [ text "The sending account ", viewAddress ctx <| account, text " has insufficient (nonstaked) funds" ]
+            { content = let url = "https://developers.concordium.com/en/testnet4/testnet/references/manage-accounts.html#account-balances"
+                        in [ text "The sending account ", viewAddress ctx <| account, text " has insufficient funds. Note: only funds that are not staked or locked can be transferred (see "
+                           , link [ onClick <| UrlClicked <| Browser.External url ]
+                                                           { url = url
+                                                           , label = el [ Font.underline ] <| text "account balances"
+                                                           }
+                           , text " documentation)."
+                           ]
             , details = Nothing
             }
 

--- a/src/client/elm/Explorer/View.elm
+++ b/src/client/elm/Explorer/View.elm
@@ -699,7 +699,7 @@ rejectionToItem ctx reason =
             }
 
         AmountTooLarge account amount ->
-            { content = [ text "The sending account ", viewAddress ctx <| account, text " has insufficient funds" ]
+            { content = [ text "The sending account ", viewAddress ctx <| account, text " has insufficient (nonstaked) funds" ]
             , details = Nothing
             }
 


### PR DESCRIPTION
## Purpose

In the `AmountTooLarge` rejected transaction case, we say that the account has insufficient funds. In the case where a baker has a large account balance that is staked, they might wonder why their transfer didn't get through. I want to clarify that the insufficient-balance error refers to nonstaked funds.