### PR TITLE
Multiple block-explorer changes

### DIFF
--- a/src/client/elm/Api.elm
+++ b/src/client/elm/Api.elm
@@ -10,7 +10,7 @@ import Json.Decode as D
 import Json.Decode.Pipeline exposing (optional, required)
 import Time exposing (Posix)
 import Transaction.Summary as TxSummary
-import Types as T exposing (BlockHash)
+import Types as T
 
 
 type alias Config =
@@ -119,7 +119,7 @@ type alias BlockInfo =
 
 type BlockResponse
     = Block BlockInfo
-    | BlockNotFound BlockHash
+    | BlockNotFound T.BlockHash
 
 
 blockResponseDecoder : String -> D.Decoder BlockResponse

--- a/src/client/elm/Api.elm
+++ b/src/client/elm/Api.elm
@@ -10,7 +10,7 @@ import Json.Decode as D
 import Json.Decode.Pipeline exposing (optional, required)
 import Time exposing (Posix)
 import Transaction.Summary as TxSummary
-import Types as T
+import Types as T exposing (BlockHash)
 
 
 type alias Config =
@@ -97,7 +97,7 @@ consensusStatusDecoder =
 
 getBlockInfo : Config -> T.BlockHash -> (ApiResult BlockResponse -> msg) -> Cmd msg
 getBlockInfo cfg blockhash msg =
-    getMiddleware cfg ("/v1/blockInfo/" ++ blockhash) blockResponseDecoder msg
+    getMiddleware cfg ("/v1/blockInfo/" ++ blockhash) (blockResponseDecoder blockhash) msg
 
 
 type alias BlockInfo =
@@ -119,14 +119,14 @@ type alias BlockInfo =
 
 type BlockResponse
     = Block BlockInfo
-    | BlockNotFound
+    | BlockNotFound BlockHash
 
 
-blockResponseDecoder : D.Decoder BlockResponse
-blockResponseDecoder =
+blockResponseDecoder : String -> D.Decoder BlockResponse
+blockResponseDecoder hash =
     D.oneOf
         [ D.map Block blockInfoDecoder
-        , D.null BlockNotFound
+        , D.null <| BlockNotFound hash
         ]
 
 

--- a/src/client/elm/Api.elm
+++ b/src/client/elm/Api.elm
@@ -95,9 +95,9 @@ consensusStatusDecoder =
 -- BlockInfo
 
 
-getBlockInfo : Config -> T.BlockHash -> (ApiResult BlockInfo -> msg) -> Cmd msg
+getBlockInfo : Config -> T.BlockHash -> (ApiResult BlockResponse -> msg) -> Cmd msg
 getBlockInfo cfg blockhash msg =
-    getMiddleware cfg ("/v1/blockInfo/" ++ blockhash) blockInfoDecoder msg
+    getMiddleware cfg ("/v1/blockInfo/" ++ blockhash) blockResponseDecoder msg
 
 
 type alias BlockInfo =
@@ -115,6 +115,19 @@ type alias BlockInfo =
     , blockHeight : Int
     , blockBaker : Int
     }
+
+
+type BlockResponse
+    = Block BlockInfo
+    | BlockNotFound
+
+
+blockResponseDecoder : D.Decoder BlockResponse
+blockResponseDecoder =
+    D.oneOf
+        [ D.map Block blockInfoDecoder
+        , D.null BlockNotFound
+        ]
 
 
 blockInfoDecoder : D.Decoder BlockInfo

--- a/src/client/elm/Explorer.elm
+++ b/src/client/elm/Explorer.elm
@@ -97,15 +97,12 @@ update msg model =
                     , getBlockSummary model.config blockInfo.blockHash ReceivedBlockSummary
                     )
 
-                Ok Api.BlockNotFound ->
-                    let blockStr = case model.blockHash of
-                                        Just hash -> "Block with hash " ++ hash
-                                        Nothing -> "Block with given hash"
-                    in ( { model
-                           | blockInfo = Failure <| BadBody <| blockStr ++ " does not exist on the chain."
-                         }
-                       , Cmd.none
-                       )
+                Ok (Api.BlockNotFound hash) ->
+                    ( { model
+                        | blockInfo = Failure <| BadBody <| "Block with hash '" ++ hash ++ "' does not exist on the chain."
+                      }
+                    , Cmd.none
+                    )
 
                 _ ->
                     ( model, Cmd.none )

--- a/src/client/elm/Explorer.elm
+++ b/src/client/elm/Explorer.elm
@@ -4,6 +4,7 @@ import Api exposing (ApiResult)
 import Dict exposing (Dict)
 import Explorer.Request exposing (..)
 import Helpers exposing (toggleSetMember)
+import Http exposing (Error(..))
 import Paging
 import RemoteData exposing (..)
 import Set exposing (Set)
@@ -51,7 +52,7 @@ type alias Model =
 
 type Msg
     = ReceivedConsensusStatus (ApiResult Api.ConsensusStatus)
-    | ReceivedBlockInfo (ApiResult Api.BlockInfo)
+    | ReceivedBlockResponse (ApiResult Api.BlockResponse)
     | ReceivedBlockSummary (ApiResult BlockSummary)
     | Display DisplayMsg
     | TransactionPaging Paging.Msg
@@ -80,15 +81,15 @@ update msg model =
             case res of
                 Ok consensusStatus ->
                     ( { model | blockInfo = Loading }
-                    , Api.getBlockInfo model.config consensusStatus.bestBlock ReceivedBlockInfo
+                    , Api.getBlockInfo model.config consensusStatus.bestBlock ReceivedBlockResponse
                     )
 
                 Err err ->
                     ( model, Cmd.none )
 
-        ReceivedBlockInfo blockInfoRes ->
+        ReceivedBlockResponse blockInfoRes ->
             case blockInfoRes of
-                Ok blockInfo ->
+                Ok (Api.Block blockInfo) ->
                     ( { model
                         | blockInfo = Success blockInfo
                         , blockSummary = Loading
@@ -96,7 +97,17 @@ update msg model =
                     , getBlockSummary model.config blockInfo.blockHash ReceivedBlockSummary
                     )
 
-                Err err ->
+                Ok Api.BlockNotFound ->
+                    let blockStr = case model.blockHash of
+                                        Just hash -> "Block with hash " ++ hash
+                                        Nothing -> "Block with given hash"
+                    in ( { model
+                           | blockInfo = Failure <| BadBody <| blockStr ++ " does not exist on the chain."
+                         }
+                       , Cmd.none
+                       )
+
+                _ ->
                     ( model, Cmd.none )
 
         ReceivedBlockSummary blockSummaryResult ->

--- a/src/client/elm/Explorer/View.elm
+++ b/src/client/elm/Explorer/View.elm
@@ -15,7 +15,6 @@ import Html
 import Html.Attributes exposing (style)
 import Icons exposing (..)
 import List
-import Network.Node exposing (eventsWidth)
 import Paging
 import Palette exposing (withAlphaEl)
 import Regex exposing (..)
@@ -1478,10 +1477,14 @@ isEven : Int -> Bool
 isEven n =
     modBy 2 n == 0
 
-wrapAttributes : List (Attribute msg)
-wrapAttributes = width fill :: List.map htmlAttribute [ style "word-break" "break-word", eventsWidth ]
 
+wrapAttributes : List (Attribute msg)
+wrapAttributes = width fill :: List.map htmlAttribute [ style "word-break" "break-word" ]
+
+
+eventElem : List (Element msg) -> List (Element msg)
 eventElem es = [ paragraph wrapAttributes es ]
+
 
 viewTransactionEvent : Theme a -> TransactionEvent -> TransactionEventItem Msg
 viewTransactionEvent ctx txEvent =

--- a/src/client/elm/Explorer/View.elm
+++ b/src/client/elm/Explorer/View.elm
@@ -99,6 +99,17 @@ viewBlockSummary theme { blockSummary, state } =
             blockSummary.transactionSummaries
                 |> List.map (viewTransactionSummary theme)
 
+        transactionNum = List.length transactionSummaries
+
+        transactionPlural = if transactionNum == 1 then " transaction" else " transactions"
+
+        transactionNumStr =  if List.isEmpty transactionSummaries
+                             then ""
+                             else " (" ++ (String.fromInt transactionNum) ++ transactionPlural ++ ")"
+
+        transactionSummariesDescription =
+            "Transactions included in this block" ++ transactionNumStr
+
         transactionPaging =
             Paging.paging state.transactionPagingModel transactionSummaries
 
@@ -114,7 +125,7 @@ viewBlockSummary theme { blockSummary, state } =
     in
     column [ width fill ]
         [ section <|
-            titleWithSubtitle theme "Transactions" "Transactions included in this block"
+            titleWithSubtitle theme "Transactions" transactionSummariesDescription
                 :: (if List.isEmpty transactionSummaries then
                         [ column [ width fill, padding 20 ] [ el [ centerX, Font.color theme.palette.fg2 ] <| text "No transactions in this block." ] ]
 

--- a/src/client/elm/Main.elm
+++ b/src/client/elm/Main.elm
@@ -261,7 +261,7 @@ update msg model =
                                             Api.getBlockInfo
                                                 model.explorerModel.config
                                                 hash
-                                                (ExplorerMsg << Explorer.ReceivedBlockInfo)
+                                                (ExplorerMsg << Explorer.ReceivedBlockResponse)
                                         )
                                     |> Maybe.withDefault Cmd.none
 
@@ -353,7 +353,7 @@ onRouteInit page model =
 
         Route.Chain (Just hash) ->
             ( { model | chainModel = Chain.selectBlock model.chainModel hash }
-            , Api.getBlockInfo model.explorerModel.config hash (ExplorerMsg << Explorer.ReceivedBlockInfo)
+            , Api.getBlockInfo model.explorerModel.config hash (ExplorerMsg << Explorer.ReceivedBlockResponse)
             )
 
         Route.Lookup (Just txHash) ->

--- a/src/client/elm/TimeHelpers.elm
+++ b/src/client/elm/TimeHelpers.elm
@@ -16,8 +16,6 @@ formatTime zone posix =
         ++ (String.padLeft 2 '0' <| String.fromInt <| Time.toMinute zone posix)
         ++ ":"
         ++ (String.padLeft 2 '0' <| String.fromInt <| Time.toSecond zone posix)
-        ++ "."
-        ++ (String.padLeft 3 '0' <| String.fromInt <| Time.toMillis zone posix)
         -- @TODO use the timezone lookup in future
         ++ " UTC"
 

--- a/src/client/elm/TimeHelpers.elm
+++ b/src/client/elm/TimeHelpers.elm
@@ -16,6 +16,8 @@ formatTime zone posix =
         ++ (String.padLeft 2 '0' <| String.fromInt <| Time.toMinute zone posix)
         ++ ":"
         ++ (String.padLeft 2 '0' <| String.fromInt <| Time.toSecond zone posix)
+        ++ "."
+        ++ (String.padLeft 2 '0' <| String.left 2 <| String.fromInt <| Time.toMillis zone posix)
         -- @TODO use the timezone lookup in future
         ++ " UTC"
 


### PR DESCRIPTION
- Displaying the number of transactions in block explorer (#10).
![Screenshot from 2021-05-05 14-52-23](https://user-images.githubusercontent.com/394853/117416346-8ed06f80-af19-11eb-8198-28a012155afd.png)

- Removing milliseconds from time stamp. This removes, in my opinion, redundant information, and makes the line shorter, avoiding text overflow.
![Screenshot from 2021-05-07 09-50-49](https://user-images.githubusercontent.com/394853/117416493-b9222d00-af19-11eb-8047-f722825eb611.png)

- Display error when exploring nonexisting blocks (#15)
![Screenshot from 2021-05-07 09-51-26](https://user-images.githubusercontent.com/394853/117416614-d525ce80-af19-11eb-9fc9-42bdbf2574f3.png)
