### PR TITLE
Updating foundation account gives an index instead of an account

### DIFF
--- a/src/client/elm/Explorer/Request.elm
+++ b/src/client/elm/Explorer/Request.elm
@@ -93,12 +93,12 @@ type alias UpdateQueues =
     , microGTUPerEuro : UpdateQueue Relation
     , protocol : UpdateQueue ProtocolUpdate
     , gasRewards : UpdateQueue GasRewards
-    , foundationAccount : UpdateQueue T.AccountAddress
+    , foundationAccount : UpdateQueue Int
     , electionDifficulty : UpdateQueue Float
     , euroPerEnergy : UpdateQueue Relation
     , bakerStakeThreshold : UpdateQueue T.Amount
-    , anonymityRevoker: UpdateQueue AnonymityRevokerInfo
-    , identityProvider: UpdateQueue IdentityProviderInfo
+    , anonymityRevoker : UpdateQueue AnonymityRevokerInfo
+    , identityProvider : UpdateQueue IdentityProviderInfo
     }
 
 
@@ -154,12 +154,13 @@ updateQueuesDecoder =
         |> required "microGTUPerEuro" (updateQueueDecoder relationDecoder)
         |> required "protocol" (updateQueueDecoder protocolUpdateDecoder)
         |> required "gasRewards" (updateQueueDecoder gasRewardsDecoder)
-        |> required "foundationAccount" (updateQueueDecoder T.accountAddressDecoder)
+        |> required "foundationAccount" (updateQueueDecoder D.int)
         |> required "electionDifficulty" (updateQueueDecoder D.float)
         |> required "euroPerEnergy" (updateQueueDecoder relationDecoder)
         |> required "bakerStakeThreshold" (updateQueueDecoder T.decodeAmount)
         |> required "addAnonymityRevoker" (updateQueueDecoder arDecoder)
         |> required "addIdentityProvider" (updateQueueDecoder ipDecoder)
+
 
 updateQueueDecoder : D.Decoder a -> D.Decoder (UpdateQueue a)
 updateQueueDecoder decoder =

--- a/src/client/elm/Explorer/View.elm
+++ b/src/client/elm/Explorer/View.elm
@@ -1888,7 +1888,7 @@ viewEventUpdateEnqueuedDetails ctx event =
                 ]
 
         FoundationAccountPayload foundationAccount ->
-            paragraph [] [ text "Update the Foundation account to be ", viewAddress ctx <| T.AddressAccount foundationAccount ]
+            paragraph [] [ text <| "Update the Foundation account to be acount with index " ++ String.fromInt foundationAccount ]
 
         RootKeysUpdatePayload _ ->
             paragraph [] [ text "Update the chain-update root keys." ]

--- a/src/client/elm/Explorer/View.elm
+++ b/src/client/elm/Explorer/View.elm
@@ -990,7 +990,7 @@ listUpdatePayloads queues =
         ++ mapUpdate MicroGtuPerEuroPayload queues.microGTUPerEuro
         ++ mapUpdate ProtocolUpdatePayload queues.protocol
         ++ mapUpdate GasRewardsPayload queues.gasRewards
-        ++ mapUpdate FoundationAccountPayload queues.foundationAccount
+        ++ mapUpdate (\i -> FoundationAccountPayload (Index i)) queues.foundationAccount
         ++ mapUpdate ElectionDifficultyPayload queues.electionDifficulty
         ++ mapUpdate EuroPerEnergyPayload queues.euroPerEnergy
         ++ mapUpdate MintDistributionPayload queues.mintDistribution
@@ -1888,7 +1888,7 @@ viewEventUpdateEnqueuedDetails ctx event =
                 ]
 
         FoundationAccountPayload foundationAccount ->
-            paragraph [] [ text <| "Update the Foundation account to be acount with index " ++ String.fromInt foundationAccount ]
+            paragraph [] [ text "Update the Foundation account to ", viewFoundationAccount ctx foundationAccount ]
 
         RootKeysUpdatePayload _ ->
             paragraph [] [ text "Update the chain-update root keys." ]
@@ -1916,6 +1916,16 @@ viewEventUpdateEnqueuedDetails ctx event =
 
         AddIdentityProviderPayload (IpInfo identityProviderInfo) ->
             paragraph [] <| text "Add a new identity provider. " :: displayArIp identityProviderInfo
+
+
+viewFoundationAccount : Theme a -> FoundationAccountRepresentation -> Element Msg
+viewFoundationAccount ctx repr =
+    case repr of
+        Index index ->
+            text <| "index " ++ String.fromInt index
+
+        Address foundationAccount ->
+            viewAddress ctx <| T.AddressAccount foundationAccount
 
 
 displayArIp : ArIpInfo -> List (Element Msg)

--- a/src/client/elm/Transaction/Event.elm
+++ b/src/client/elm/Transaction/Event.elm
@@ -213,7 +213,7 @@ type UpdatePayload
     | ElectionDifficultyPayload Float
     | EuroPerEnergyPayload Relation
     | MicroGtuPerEuroPayload Relation
-    | FoundationAccountPayload T.AccountAddress
+    | FoundationAccountPayload Int
     | RootKeysUpdatePayload HigherLevelKeys
     | Level1KeysUpdatePayload HigherLevelKeys
     | Level2KeysUpdatePayload Authorizations
@@ -297,9 +297,9 @@ type alias ProtocolUpdate =
 
 
 type alias Description =
-    { name: String
-    , url: String
-    , description: String
+    { name : String
+    , url : String
+    , description : String
     }
 
 
@@ -309,21 +309,26 @@ type Identity
     = ArIdentity Int
     | IpIdentity Int
 
+
 {-| Information about anonymity revokers or identity providers
 -}
 type alias ArIpInfo =
-    { identity: Identity
-    , description: Description
+    { identity : Identity
+    , description : Description
     }
+
 
 {-| Data for an anonymity revoker
 -}
-type AnonymityRevokerInfo = ArInfo ArIpInfo
+type AnonymityRevokerInfo
+    = ArInfo ArIpInfo
 
 
 {-| Data for an identity provider
 -}
-type IdentityProviderInfo = IpInfo ArIpInfo
+type IdentityProviderInfo
+    = IpInfo ArIpInfo
+
 
 
 -- Errors
@@ -367,7 +372,7 @@ updatePayloadDecoder =
                         relationDecoder |> D.map MicroGtuPerEuroPayload
 
                     "foundationAccount" ->
-                        T.accountAddressDecoder |> D.map FoundationAccountPayload
+                        D.int |> D.map FoundationAccountPayload
 
                     "root" ->
                         keyUpdateDecoder
@@ -419,14 +424,18 @@ gasRewardsDecoder =
 
 arDecoder : D.Decoder AnonymityRevokerInfo
 arDecoder =
-    let arIp = D.succeed ArIpInfo
+    let
+        arIp =
+            D.succeed ArIpInfo
                 |> required "arIdentity" arIdentityDecoder
                 |> required "arDescription" descriptionDecoder
-    in D.map ArInfo arIp
+    in
+    D.map ArInfo arIp
 
 
 arIdentityDecoder : D.Decoder Identity
-arIdentityDecoder = D.map ArIdentity D.int
+arIdentityDecoder =
+    D.map ArIdentity D.int
 
 
 descriptionDecoder : D.Decoder Description
@@ -439,14 +448,18 @@ descriptionDecoder =
 
 ipDecoder : D.Decoder IdentityProviderInfo
 ipDecoder =
-    let arIp = D.succeed ArIpInfo
+    let
+        arIp =
+            D.succeed ArIpInfo
                 |> required "ipIdentity" ipIdentityDecoder
                 |> required "ipDescription" descriptionDecoder
-    in D.map IpInfo arIp
+    in
+    D.map IpInfo arIp
 
 
 ipIdentityDecoder : D.Decoder Identity
-ipIdentityDecoder = D.map IpIdentity D.int
+ipIdentityDecoder =
+    D.map IpIdentity D.int
 
 
 updateKeysCollectionDecoder : D.Decoder UpdateKeysCollection

--- a/src/client/elm/Transaction/Event.elm
+++ b/src/client/elm/Transaction/Event.elm
@@ -206,6 +206,11 @@ type alias EventUpdateEnqueued =
     }
 
 
+type FoundationAccountRepresentation
+    = Index Int
+    | Address T.AccountAddress
+
+
 type UpdatePayload
     = MintDistributionPayload MintDistribution
     | TransactionFeeDistributionPayload TransactionFeeDistribution
@@ -213,7 +218,7 @@ type UpdatePayload
     | ElectionDifficultyPayload Float
     | EuroPerEnergyPayload Relation
     | MicroGtuPerEuroPayload Relation
-    | FoundationAccountPayload Int
+    | FoundationAccountPayload FoundationAccountRepresentation
     | RootKeysUpdatePayload HigherLevelKeys
     | Level1KeysUpdatePayload HigherLevelKeys
     | Level2KeysUpdatePayload Authorizations
@@ -372,7 +377,7 @@ updatePayloadDecoder =
                         relationDecoder |> D.map MicroGtuPerEuroPayload
 
                     "foundationAccount" ->
-                        D.int |> D.map FoundationAccountPayload
+                        foundationAccountRepresentationDecoder |> D.map FoundationAccountPayload
 
                     "root" ->
                         keyUpdateDecoder
@@ -396,6 +401,14 @@ updatePayloadDecoder =
                         D.fail "Unknown update type"
     in
     D.field "updateType" D.string |> D.andThen decode
+
+
+foundationAccountRepresentationDecoder : D.Decoder FoundationAccountRepresentation
+foundationAccountRepresentationDecoder =
+    D.oneOf
+        [ D.map Address T.accountAddressDecoder
+        , D.map Index D.int
+        ]
 
 
 mintDistributionDecoder : D.Decoder MintDistribution

--- a/src/client/elm/Transaction/Summary.elm
+++ b/src/client/elm/Transaction/Summary.elm
@@ -95,7 +95,10 @@ type UpdateType
     | UpdateAddAnonymityRevoker
       -- ^Add a new anonymity revoker
     | UpdateAddIdentityProvider
-      -- ^Add a new identity provider
+
+
+
+-- ^Add a new identity provider
 
 
 type TransactionResult
@@ -172,7 +175,7 @@ type RejectReason
     | RemoveFirstCredential
       -- | The credential holder of the keys to be updated did not sign the transaction
     | CredentialHolderDidNotSign
-    -- |Account is not allowed to have multiple credentials because it contains a non-zero encrypted transfer.
+      -- |Account is not allowed to have multiple credentials because it contains a non-zero encrypted transfer.
     | NotAllowedMultipleCredentials
       -- |The account is not allowed to receive encrypted transfers because it has multiple credentials.
     | NotAllowedToReceiveEncrypted


### PR DESCRIPTION
## Purpose

Block explorer fails to decode blockSummary, when an update of foundation account is queued, because the dashboard assumes the foundation account to be an account address, but the api exposes the account index instead.

## Changes

Show the foundation account index

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.