### PR TITLE
Displaying conversion rate updates

### DIFF
--- a/src/client/elm/Explorer/View.elm
+++ b/src/client/elm/Explorer/View.elm
@@ -1877,13 +1877,13 @@ viewEventUpdateEnqueuedDetails ctx event =
 
         EuroPerEnergyPayload euroPerEnergy ->
             row [ width fill ]
-                [ text "Update the Euro per energy to "
+                [ text "Update the Euro to NRG (energy) conversion rate to "
                 , viewRelation ctx euroPerEnergy
                 ]
 
         MicroGtuPerEuroPayload microGtuPerEnergy ->
             row [ width fill ]
-                [ text "Update the amount of μGTU per Euro to "
+                [ text "Update the μGTU to Euro conversion rate to "
                 , viewRelation ctx microGtuPerEnergy
                 ]
 
@@ -2005,11 +2005,7 @@ displayWebsite url =
 -}
 viewRelation : Theme a -> Relation -> Element msg
 viewRelation ctx relation =
-    column [ spacing 3 ]
-        [ el [ centerX ] <| text <| String.fromInt relation.numerator
-        , el [ width fill, Border.widthEach { top = 0, left = 0, right = 0, bottom = 1 }, Border.color ctx.palette.fg2 ] none
-        , el [ centerX ] <| text <| String.fromInt relation.denominator
-        ]
+    text <| String.fromInt relation.numerator ++ ":" ++ String.fromInt relation.denominator
 
 
 viewAsAddressContract : Theme a -> T.ContractAddress -> Element Msg


### PR DESCRIPTION
This changes the way microGTU-to-Euro and Euro-to-NRG conversion rates are phrased and displayed (see screenshots).

Original:
![Screenshot from 2021-05-18 12-10-45](https://user-images.githubusercontent.com/394853/118633772-1c417880-b7d2-11eb-9f97-aef963dbfdd9.png)

Proposed:
![Screenshot from 2021-05-18 12-11-24](https://user-images.githubusercontent.com/394853/118634082-717d8a00-b7d2-11eb-80b7-7140824bfa2c.png)
