### PR TITLE
Use .com in dashboard urls for stage- and testnet

### DIFF
--- a/src/client/elm/Config.elm
+++ b/src/client/elm/Config.elm
@@ -77,10 +77,10 @@ developmentUrl mode localUrl =
             localUrl
 
         Staging ->
-            "https://dashboard.eu.staging.concordium.software"
+            "https://dashboard.eu.staging.concordium.com"
 
         Testnet ->
-            "https://dashboard.testnet.concordium.software"
+            "https://dashboard.testnet.concordium.com"
 
         Mainnet ->
             "https://dashboard.mainnet.concordium.software"


### PR DESCRIPTION
## Purpose

We are still using `.com` for stage- and testnet.
Closes #19 

## Changes

Use `.com` instead of `.software`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.