### PR TITLE
Make contrAddr copyable in details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Fix overflow issue, making some UI elements to display text vertically
 - Fix incorrect parsing of key updates
+- Make contract addresses copyable in the details view
 
 ## [1.0.0] - (2021-05-20)

--- a/src/client/elm/Explorer/View.elm
+++ b/src/client/elm/Explorer/View.elm
@@ -1456,15 +1456,24 @@ viewTable ctx table =
                     }
                 )
                 table.columns
+
+        --| This allows the tooltips for SC's to overflow the container, while adding scrollbars for scheduled transfers
+        overflowBehavior =
+            if List.length table.data > 10 then
+                [ scrollbars ]
+
+            else
+                []
     in
     Element.indexedTable
-        [ Background.color ctx.palette.bg2
-        , Border.width 1
-        , Border.color ctx.palette.bg2
-        , Border.rounded 5
-        , htmlAttribute <| style "overflow-y" "auto"
-        , htmlAttribute <| style "max-height" "800px"
-        ]
+        ([ Background.color ctx.palette.bg2
+         , Border.width 1
+         , Border.color ctx.palette.bg2
+         , Border.rounded 5
+         , htmlAttribute <| style "max-height" "800px"
+         ]
+            ++ overflowBehavior
+        )
         { data = table.data, columns = columns }
 
 
@@ -1738,7 +1747,7 @@ viewTransactionEvent ctx txEvent =
                             [ paragraph [] [ text "Contract instance was initialized" ] ]
                             [ viewKeyValue ctx
                                 [ ( "Module", el [ stringTooltipAboveWithCopy ctx "", pointer, onClick (CopyToClipboard event.ref) ] <| text event.ref )
-                                , ( "Contract address", viewAddress ctx <| T.AddressContract event.address )
+                                , ( "Contract address", viewAsAddressContract ctx event.address )
                                 , ( "Contract", text <| event.contractName )
                                 , ( "Amount", text <| T.amountToString event.amount )
                                 ]
@@ -1766,7 +1775,7 @@ viewTransactionEvent ctx txEvent =
                         [ viewDetailRow
                             [ paragraph [] [ text "Contract instance was updated" ] ]
                             [ viewKeyValue ctx
-                                [ ( "Contract address", viewAddress ctx <| T.AddressContract event.address )
+                                [ ( "Contract address", viewAsAddressContract ctx event.address )
                                 , ( "Contract", text event.receiveName.contractName )
                                 , ( "Function", text event.receiveName.functionName )
                                 , ( "Amount", text <| T.amountToString event.amount )


### PR DESCRIPTION
## Purpose

Make contract addresses copyable from the details view.
Closes #25 

## Changes

- Make the addresses copyable.
- Allow the table contents to overflow when the number of rows is low. (This was necessary since the hover tooltips were being clipped)

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.