### PR TITLE
Added an info icon and tooltip, explaining what the purple bars on blocks mean (#53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
   - Move branches around for a more compact tree.
   - Always have the branch with the most popular best block on top.
   - Display blocks on discarded branches as greyed out.
+  - Display an info icon with tooltip, explaining what the purple bars mean.
 
 ### Fixed
 - Fix overflow issue, making some UI elements to display text vertically

--- a/src/client/elm/Chain.elm
+++ b/src/client/elm/Chain.elm
@@ -29,12 +29,16 @@ import File exposing (File)
 import Http
 import Json.Decode as Decode
 import List.Extra as List
+import Material.Icons.Sharp as MaterialIcons
+import Material.Icons.Types exposing (Coloring(..))
 import Maybe
+import Palette
 import RemoteData exposing (..)
 import Route exposing (Route)
 import Set
 import Task
 import Time exposing (..)
+import Tooltip exposing (stringTooltipAboveWidget, stringTooltipAlignedRight)
 import Transition exposing (..)
 import Tree exposing (Tree)
 
@@ -452,7 +456,12 @@ view theme model showDevTools =
                     , maxWidth = model.maxWidth
                     }
             in
-            column [ width fill, height fill, inFront (viewDebugButtons showDevTools) ]
+            column
+                [ width fill
+                , height fill
+                , inFront (viewDebugButtons showDevTools)
+                , inFront (viewInfoIcon theme "The purple bars represent the proportion of nodes which have the given block as best block.")
+                ]
                 [ el
                     [ centerX
                     , centerY
@@ -464,6 +473,18 @@ view theme model showDevTools =
 
         Nothing ->
             none
+
+
+viewInfoIcon : Theme a -> String -> Element msg
+viewInfoIcon ctx description =
+    el [ padding 17, alignRight ]
+        (el
+            [ padding 3
+            , Font.color (ctx.palette.c3 |> Palette.withAlphaEl 0.3)
+            , stringTooltipAlignedRight ctx (text description)
+            ]
+            (html <| MaterialIcons.info 16 Inherit)
+        )
 
 
 viewDebugButtons : Bool -> Element Msg

--- a/src/client/elm/Tooltip.elm
+++ b/src/client/elm/Tooltip.elm
@@ -78,6 +78,18 @@ stringTooltipAboveWidget ctx content =
         )
 
 
+stringTooltipAlignedRight : Theme a -> Element Never -> Attribute msg
+stringTooltipAlignedRight ctx content =
+    tooltip above
+        (column []
+            [ column
+                (tooltipStyle ctx ++ [ width (px 250), moveLeft 230 ])
+                [ paragraph [] [ content ] ]
+            , downArrow ctx
+            ]
+        )
+
+
 stringTooltipAboveWithCopy : Theme a -> String -> Attribute msg
 stringTooltipAboveWithCopy ctx content =
     tooltip above


### PR DESCRIPTION
## Purpose

This addresses #53, adding a small info icon with a tooltip to the chain visualisation, explaining what the purple bars mean.

## Changes

- Added purple info icon in the top right corner of the chain visualisation
