### PR TITLE
Ensure every byte is decoded when decoding CBOR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-### Changed 
+### Changed
 
 ### Fixed
 - Fixed text wrapping problem in the block explorer
+- Fixed displaying memo byte string as CBOR integer, when it contains arbitrary bytes.
 
 ## [1.0.1] - (2021-09-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Fixed text wrapping problem in the block explorer
-- Fixed displaying memo byte string as CBOR integer, when it contains arbitrary bytes.
+- Fixed parsing memo byte string as CBOR. Will only succeed if consumes all of the bytes.
 
 ## [1.0.1] - (2021-09-09)
 


### PR DESCRIPTION
## Purpose

Closes #69

## Changes

- Decoding CBOR will encode the resulting value into bytes again and compare the length with the original byte input to ensure the whole bytestring is consumed.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
