### PR TITLE
Attempt to parse registerData as CBOR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 ### Changed 
+- Attempt to parse RegisterData bytes as CBOR, similar to memo transactions.
 
 ### Fixed
 - Fixed text wrapping problem in the block explorer

--- a/src/client/elm/Explorer/View.elm
+++ b/src/client/elm/Explorer/View.elm
@@ -1810,7 +1810,7 @@ viewTransactionEvent ctx txEvent =
         TransactionEventTransferMemo event ->
             { content =
                 eventElem
-                    [ text <| "Transfer memo: " ++ memoToString event.memo
+                    [ text <| "Transfer memo: " ++ arbitraryBytesToString event.memo
                     ]
             , details = Nothing
             }
@@ -1825,7 +1825,7 @@ viewTransactionEvent ctx txEvent =
                     column [ width fill ]
                         [ viewDetailRow
                             [ paragraph [] [ text "Hex representation of the registered data:" ] ]
-                            [ paragraph [] [ text event.data ]
+                            [ paragraph [] [ text <| arbitraryBytesToString event.data ]
                             ]
                         ]
             }

--- a/src/client/elm/Transaction/Event.elm
+++ b/src/client/elm/Transaction/Event.elm
@@ -74,7 +74,7 @@ type alias EventEncryptedSelfAmountAdded =
     }
 
 
-{-| Transaction metadata which is parsed as CBOR, if this fails it fallbacks to the raw hex string.
+{-| Arbitrary bytes, which could be encoded in CBOR otherwise fallback to a hex string.
 -}
 type ArbitraryBytes
     = CborString String


### PR DESCRIPTION
## Purpose

Closes #66.

## Changes

- Rename the type for memo bytes `Memo` to `ArbitraryBytes`.
- Use `ArbitraryBytes` for the data in the register data event.
- Display details whether the bytes are interpreted as CBOR or raw.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
