### PR TITLE
Revert the word break for all events and only set for relevant

### DIFF
--- a/src/client/elm/Explorer/View.elm
+++ b/src/client/elm/Explorer/View.elm
@@ -770,12 +770,12 @@ rejectionToItem ctx reason =
             }
 
         InvalidInitMethod moduleRef initName ->
-            { content = [ text "No contract '", text initName, text "' found in module ", text moduleRef ]
+            { content = [ text "No contract '", el [ wordBreak ] <| text initName, text "' found in module ", text moduleRef ]
             , details = Nothing
             }
 
         InvalidReceiveMethod moduleRef receiveName ->
-            { content = [ text "No receive function '", text receiveName.functionName, text " of contract '", text receiveName.contractName, text "' found in module ", text moduleRef ]
+            { content = [ text "No receive function '", el [ wordBreak ] <| text receiveName.functionName, text " of contract '", text receiveName.contractName, text "' found in module ", text moduleRef ]
             , details = Nothing
             }
 
@@ -1504,7 +1504,21 @@ isEven n =
 
 eventElem : List (Element msg) -> List (Element msg)
 eventElem es =
-    [ paragraph [ width fill, htmlAttribute <| style "word-break" "break-word" ] es ]
+    [ wrappedRow [ width fill ] es ]
+
+
+{-| Allow text to break words when wrapping around
+-}
+wordBreak : Attribute msg
+wordBreak =
+    htmlAttribute <| style "word-break" "break-word"
+
+
+{-| Disallow text to break words when wrapping around
+-}
+noWordBreak : Attribute msg
+noWordBreak =
+    htmlAttribute <| style "word-break" "normal"
 
 
 viewTransactionEvent : Theme a -> TransactionEvent -> TransactionEventItem Msg
@@ -1734,7 +1748,9 @@ viewTransactionEvent ctx txEvent =
         TransactionEventContractInitialized event ->
             { content =
                 eventElem
-                    [ text <| "Instantiated contract '" ++ event.contractName ++ "' with address: "
+                    [ text <| "Instantiated contract '"
+                    , el [ wordBreak ] <| text event.contractName
+                    , text "' with address: "
                     , viewAsAddressContract ctx event.address
                     , text <| " from module: " ++ String.left 8 event.ref
                     ]
@@ -1756,7 +1772,7 @@ viewTransactionEvent ctx txEvent =
                                 paragraph [ Font.center ] [ text "No events" ]
 
                               else
-                                viewKeyValue ctx <| List.indexedMap (\i e -> ( String.fromInt i, text e )) event.events
+                                viewKeyValue ctx <| List.indexedMap (\i e -> ( String.fromInt i, paragraph [ wordBreak ] [ text e ] )) event.events
                             ]
                         ]
             }
@@ -1785,7 +1801,7 @@ viewTransactionEvent ctx txEvent =
                                 paragraph [ Font.center ] [ text "No events" ]
 
                               else
-                                viewKeyValue ctx <| List.indexedMap (\i e -> ( String.fromInt i, text e )) event.events
+                                viewKeyValue ctx <| List.indexedMap (\i e -> ( String.fromInt i, paragraph [ wordBreak ] [ text e ] )) event.events
                             ]
                         ]
             }
@@ -1804,7 +1820,7 @@ viewTransactionEvent ctx txEvent =
         TransactionEventTransferMemo event ->
             { content =
                 eventElem
-                    [ text <| "Transfer memo: " ++ arbitraryBytesToString event.memo
+                    [ paragraph [ wordBreak ] [ text <| "Transfer memo: " ++ arbitraryBytesToString event.memo ]
                     ]
             , details = Nothing
             }
@@ -1819,7 +1835,7 @@ viewTransactionEvent ctx txEvent =
                     column [ width fill ]
                         [ viewDetailRow
                             [ paragraph [] [ text "Hex representation of the registered data:" ] ]
-                            [ paragraph [] [ text <| arbitraryBytesToString event.data ]
+                            [ paragraph [ wordBreak ] [ text <| arbitraryBytesToString event.data ]
                             ]
                         ]
             }
@@ -2050,6 +2066,7 @@ viewAsAddressContract ctx contractAddress =
         [ stringTooltipAboveWithCopy ctx content
         , pointer
         , onClick (CopyToClipboard content)
+        , noWordBreak
         ]
     <|
         viewAddress ctx <|


### PR DESCRIPTION
## Purpose

Closes #40 and closes #64.

## Changes

Revert parts of PR #62 which allows words to break for every event displayed.
Instead, this is only set for contract names, contract events, memos and registered data

Blocks on testnet: 
- Large memo: ce6f805390b9c0ac42aefcbe7507391b90c4348f23b1c2be76b6030d5d6571a4
- Previously broken event: ef8faec0655b55422c50b14f0f9ab2df72d36fc38d92596345113aae2abec805

Blocks on stagenet:
- Long contract name: 5b4ef7078aec607a380350bfcb274b717b70f67945d6d68d8579f0a6e69bc5f7

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
*This is already in the changelog*
