### PR TITLE
Make sure that deep links still fetches resources from root

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = {
   mode: isProduction ? 'production' : 'development',
   output: {
     filename: `[name]-[contenthash:8]-bundle.js`,
+    publicPath: '/', // Will ensure deep links still fetches resources from the root.
     clean: true,
   },
   resolve: {
@@ -55,8 +56,6 @@ module.exports = {
   ],
   devServer: {
     port: 3001,
-    historyApiFallback: {
-      index: '/index.html',
-    },
+    historyApiFallback: true,
   },
 };


### PR DESCRIPTION
## Purpose

When navigating to a deep link such as `/chain/ea596a8b25fbe94673651b3687e8a726810a732a0faee7ae86721af345c043cs` it would attempt to get resources relative to `/chain`.
This PR ensures the resources are absolute from `/`.

## Changes

- Set absolute paths for webpack build
- Simplify `historyApiFallback` since we are using the default setting.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

