### PR TITLE
Format dates according to the local timezone and display the UTC offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Make GTU per Euro update in block explorer more readable.
 - Remove dead link to account documentation.
 - Attempt to parse RegisterData bytes as CBOR, similar to memo transactions.
+- Display dates in local time and with UTC offset.
 
 ### Fixed
 - Fixed text wrapping problem in the block explorer

--- a/src/elm/Chain.elm
+++ b/src/elm/Chain.elm
@@ -480,7 +480,7 @@ viewInfoIcon ctx description =
     el [ padding 17, alignRight ]
         (el
             [ padding 3
-            , Font.color (ctx.palette.c3 |> Palette.withAlphaEl 0.3)
+            , Font.color (ctx.palette.c3 |> Palette.withAlphaEl 0.7)
             , stringTooltipAlignedRight ctx (text description)
             ]
             (html <| MaterialIcons.info 16 Inherit)

--- a/src/elm/Chain.elm
+++ b/src/elm/Chain.elm
@@ -480,7 +480,7 @@ viewInfoIcon ctx description =
     el [ padding 17, alignRight ]
         (el
             [ padding 3
-            , Font.color (ctx.palette.c3 |> Palette.withAlphaEl 0.7)
+            , Font.color (ctx.palette.c3 |> Palette.withAlphaEl 0.3)
             , stringTooltipAlignedRight ctx (text description)
             ]
             (html <| MaterialIcons.info 16 Inherit)

--- a/src/elm/Explorer/View.elm
+++ b/src/elm/Explorer/View.elm
@@ -3,7 +3,6 @@ module Explorer.View exposing (..)
 import Api exposing (BlockInfo)
 import Browser exposing (UrlRequest)
 import Context exposing (Theme)
-import Css exposing (space)
 import Dict exposing (Dict)
 import Element exposing (..)
 import Element.Background as Background
@@ -360,10 +359,7 @@ viewSlotTime ctx timezone blockInfo =
             blockColor ctx blockInfo.finalized
 
         slotTime =
-            -- @TODO add timezone support?
             TimeHelpers.formatTime timezone blockInfo.blockSlotTime
-
-        -- Formatting.formatTimeBetween blockInfo.blockSlotTime ctx.time
     in
     row
         [ height fill

--- a/src/elm/Explorer/View.elm
+++ b/src/elm/Explorer/View.elm
@@ -3,6 +3,7 @@ module Explorer.View exposing (..)
 import Api exposing (BlockInfo)
 import Browser exposing (UrlRequest)
 import Context exposing (Theme)
+import Css exposing (space)
 import Dict exposing (Dict)
 import Element exposing (..)
 import Element.Background as Background
@@ -74,16 +75,16 @@ finalizationRewardAccountLower =
     toLower finalizationRewardAccountUpper
 
 
-view : Theme a -> Model -> Element Msg
-view theme model =
+view : Theme a -> Time.Zone -> Model -> Element Msg
+view theme timezone model =
     column [ spacing 40, width fill ]
         [ viewContainer theme
             (remoteDataView theme.palette
                 (\blockInfo ->
                     column
                         [ width fill ]
-                        [ viewHeader theme blockInfo
-                        , remoteDataView theme.palette (viewBlockSummary theme) model.blockSummary
+                        [ viewHeader theme timezone blockInfo
+                        , remoteDataView theme.palette (viewBlockSummary theme timezone) model.blockSummary
                         ]
                 )
                 model.blockInfo
@@ -91,12 +92,12 @@ view theme model =
         ]
 
 
-viewBlockSummary : Theme a -> DisplayDetailBlockSummary -> Element Msg
-viewBlockSummary theme { blockSummary, state } =
+viewBlockSummary : Theme a -> Time.Zone -> DisplayDetailBlockSummary -> Element Msg
+viewBlockSummary theme timezone { blockSummary, state } =
     let
         transactionSummaries =
             blockSummary.transactionSummaries
-                |> List.map (viewTransactionSummary theme)
+                |> List.map (viewTransactionSummary theme timezone)
 
         transactionNum =
             List.length transactionSummaries
@@ -169,7 +170,7 @@ viewBlockSummary theme { blockSummary, state } =
             ]
         , section
             [ titleWithSubtitle theme "Updates" "Updates queued at the time of this block"
-            , viewUpdates theme blockSummary.updates
+            , viewUpdates theme timezone blockSummary.updates
             ]
         ]
 
@@ -256,12 +257,13 @@ viewContainer ctx content =
         content
 
 
-viewHeader : Theme a -> BlockInfo -> Element Msg
-viewHeader theme blockInfo =
-    row ([ width fill, spacing 15, paddingXY 6 0 ] ++ bottomBorder theme)
+viewHeader : Theme a -> Time.Zone -> BlockInfo -> Element Msg
+viewHeader theme timezone blockInfo =
+    row ([ width fill, spacing 10, paddingXY 6 0 ] ++ bottomBorder theme)
         [ viewParentLink theme blockInfo
         , viewBlockHash theme blockInfo.blockHash blockInfo.finalized
-        , viewBlockStats theme blockInfo
+        , viewBlockHeight theme blockInfo
+        , viewSlotTime theme timezone blockInfo
         ]
 
 
@@ -351,46 +353,40 @@ blockIcon finalized =
         Icons.block_not_finalized
 
 
-viewBlockStats : Theme a -> BlockInfo -> Element Msg
-viewBlockStats ctx blockInfo =
-    row [ alignRight, spacing 15 ]
-        [ viewBlockHeight ctx blockInfo
-        , viewSlotTime ctx blockInfo
-        ]
-
-
-viewSlotTime : Theme a -> BlockInfo -> Element Msg
-viewSlotTime ctx blockInfo =
+viewSlotTime : Theme a -> Time.Zone -> BlockInfo -> Element Msg
+viewSlotTime ctx timezone blockInfo =
     let
         color =
             blockColor ctx blockInfo.finalized
 
         slotTime =
             -- @TODO add timezone support?
-            TimeHelpers.formatTime Time.utc blockInfo.blockSlotTime
+            TimeHelpers.formatTime timezone blockInfo.blockSlotTime
 
         -- Formatting.formatTimeBetween blockInfo.blockSlotTime ctx.time
     in
     row
         [ height fill
-        , spacing 10
+        , spacing 2
         , Font.color color
         , alignRight
         ]
-        [ el [ Font.color (withAlphaEl 0.5 <| color) ]
+        [ el [ Font.color (withAlphaEl 0.8 <| color) ]
             (html <| Icons.time_stopwatch 20)
-        , el
-            [ Font.color color
-            , stringTooltipAbove ctx "Slot time"
+        , row [ spacing 8 ]
+            [ el
+                [ Font.color color
+                , stringTooltipAbove ctx "Slot time"
+                ]
+                (text slotTime)
+            , el
+                [ Font.color (withAlphaEl 0.8 <| color)
+                , stringTooltipAbove ctx "Copy to clipboard"
+                , pointer
+                , onClick (CopyToClipboard slotTime)
+                ]
+                (html <| Icons.copy_to_clipboard 18)
             ]
-            (text slotTime)
-        , el
-            [ Font.color (withAlphaEl 0.5 <| color)
-            , stringTooltipAbove ctx "Copy to clipboard"
-            , pointer
-            , onClick (CopyToClipboard slotTime)
-            ]
-            (html <| Icons.copy_to_clipboard 18)
         ]
 
 
@@ -402,7 +398,7 @@ viewBlockHeight ctx blockInfo =
     in
     row
         [ height fill
-        , spacing 10
+        , spacing 2
         , Font.color color
         , alignRight
         , stringTooltipAbove ctx "Chain length"
@@ -466,8 +462,8 @@ type alias TransactionEventItem msg =
     }
 
 
-viewTransactionSummary : Theme a -> TransactionSummary -> SummaryItem Msg
-viewTransactionSummary ctx txSummary =
+viewTransactionSummary : Theme a -> Time.Zone -> TransactionSummary -> SummaryItem Msg
+viewTransactionSummary ctx timezone txSummary =
     let
         typeDecription =
             typeDescriptionTransactionSummaryType txSummary.tipe
@@ -500,7 +496,7 @@ viewTransactionSummary ctx txSummary =
         viewMainEventItem event =
             let
                 item =
-                    viewTransactionEvent ctx event
+                    viewTransactionEvent ctx timezone event
             in
             { content =
                 row contentRowAttrs <|
@@ -526,7 +522,7 @@ viewTransactionSummary ctx txSummary =
         viewSubEvent event =
             let
                 item =
-                    viewTransactionEvent ctx event
+                    viewTransactionEvent ctx timezone event
             in
             { content =
                 row contentRowAttrs <|
@@ -915,8 +911,8 @@ rejectionToItem ctx reason =
             }
 
 
-viewUpdates : Theme a -> Updates -> Element Msg
-viewUpdates theme updates =
+viewUpdates : Theme a -> Time.Zone -> Updates -> Element Msg
+viewUpdates theme timezone updates =
     let
         allQueuedUpdates =
             listUpdatePayloads updates.updateQueues
@@ -928,13 +924,7 @@ viewUpdates theme updates =
         viewUpdate : EventUpdateEnqueued -> Element Msg
         viewUpdate update =
             updateRow
-                (el
-                    [ Font.color theme.palette.fg1 ]
-                 <|
-                    text <|
-                        TimeHelpers.formatTime Time.utc <|
-                            update.effectiveTime
-                )
+                (el [ Font.color theme.palette.fg1 ] <| text <| TimeHelpers.formatTime timezone update.effectiveTime)
                 (viewEventUpdateEnqueuedDetails theme update)
     in
     if List.isEmpty allQueuedUpdates then
@@ -1521,8 +1511,8 @@ noWordBreak =
     htmlAttribute <| style "word-break" "normal"
 
 
-viewTransactionEvent : Theme a -> TransactionEvent -> TransactionEventItem Msg
-viewTransactionEvent ctx txEvent =
+viewTransactionEvent : Theme a -> Time.Zone -> TransactionEvent -> TransactionEventItem Msg
+viewTransactionEvent ctx timezone txEvent =
     case txEvent of
         -- Transfers
         TransactionEventTransferred event ->
@@ -1558,7 +1548,7 @@ viewTransactionEvent ctx txEvent =
                                 , columns =
                                     [ { header = text "Release date"
                                       , width = fill
-                                      , view = \i ( timestamp, _ ) -> el [ centerX ] <| text <| TimeHelpers.formatTime Time.utc timestamp
+                                      , view = \i ( timestamp, _ ) -> el [ centerX ] <| text <| TimeHelpers.formatTime timezone timestamp
                                       }
                                     , { header = text "Amount"
                                       , width = fill
@@ -1809,7 +1799,7 @@ viewTransactionEvent ctx txEvent =
         TransactionEventUpdateEnqueued event ->
             { content =
                 eventElem
-                    [ text <| "Update enqueued to take effect " ++ TimeHelpers.formatTime Time.utc event.effectiveTime
+                    [ text <| "Update enqueued to take effect " ++ TimeHelpers.formatTime timezone event.effectiveTime
                     ]
             , details =
                 Just <|

--- a/src/elm/Lookup.elm
+++ b/src/elm/Lookup.elm
@@ -15,6 +15,7 @@ import List
 import RemoteData exposing (WebData)
 import Route exposing (Route)
 import Set exposing (Set)
+import Time
 import Types as T
 import Widgets
 
@@ -92,14 +93,14 @@ update msg model =
             ( model, Cmd.none )
 
 
-view : Theme a -> Model -> Element Msg
-view theme model =
+view : Theme a -> Time.Zone -> Model -> Element Msg
+view theme timezone model =
     column
         [ spacing 40
         , width fill
         ]
         [ viewTransactionSearch theme model
-        , viewTransactionStatusWebData theme model.transactionStatusResult
+        , viewTransactionStatusWebData theme timezone model.transactionStatusResult
         ]
 
 
@@ -147,8 +148,8 @@ viewTransactionSearch theme model =
         ]
 
 
-viewTransactionStatusWebData : Theme a -> WebData DisplayDetailTransactionStatusResponse -> Element Msg
-viewTransactionStatusWebData theme remoteData =
+viewTransactionStatusWebData : Theme a -> Time.Zone -> WebData DisplayDetailTransactionStatusResponse -> Element Msg
+viewTransactionStatusWebData theme timezone remoteData =
     case remoteData of
         RemoteData.NotAsked ->
             Element.none
@@ -160,16 +161,16 @@ viewTransactionStatusWebData theme remoteData =
             el [ Font.color theme.palette.danger, centerX ] (paragraph [] [ text <| "Error: " ++ Widgets.errorToString error ])
 
         RemoteData.Success data ->
-            viewTransactionStatus theme data
+            viewTransactionStatus theme timezone data
 
 
-viewTransactionStatus : Theme a -> DisplayDetailTransactionStatusResponse -> Element Msg
-viewTransactionStatus theme data =
+viewTransactionStatus : Theme a -> Time.Zone -> DisplayDetailTransactionStatusResponse -> Element Msg
+viewTransactionStatus theme timezone data =
     let
         viewTransactionStatusBlock finalized index ( blockHash, txSummary ) =
             let
                 item =
-                    mapSummaryItem explorerToLookupMsg <| viewTransactionSummary theme txSummary
+                    mapSummaryItem explorerToLookupMsg <| viewTransactionSummary theme timezone txSummary
 
                 displayedEvents =
                     data.detailsDisplayed

--- a/src/elm/TimeHelpers.elm
+++ b/src/elm/TimeHelpers.elm
@@ -19,10 +19,12 @@ formatTime zone posix =
         ++ (String.padLeft 2 '0' <| String.fromInt <| Time.toSecond zone posix)
         ++ "."
         ++ (String.padLeft 2 '0' <| String.left 2 <| String.fromInt <| Time.toMillis zone posix)
-        -- @TODO use the timezone lookup in future
+        ++ " "
         ++ formatTimezone zone posix
 
 
+{-| Display the timezone as UTC offset
+-}
 formatTimezone : Time.Zone -> Time.Posix -> String
 formatTimezone zone posix =
     let
@@ -36,7 +38,7 @@ formatTimezone zone posix =
             else
                 "+"
     in
-    " UTC" ++ sign ++ String.fromInt offset
+    "UTC" ++ sign ++ String.fromInt offset
 
 
 monthToInt : Time.Month -> Int

--- a/src/elm/TimeHelpers.elm
+++ b/src/elm/TimeHelpers.elm
@@ -1,6 +1,7 @@
 module TimeHelpers exposing (..)
 
 import Time
+import Time.Extra exposing (toOffset)
 
 
 formatTime : Time.Zone -> Time.Posix -> String
@@ -19,7 +20,23 @@ formatTime zone posix =
         ++ "."
         ++ (String.padLeft 2 '0' <| String.left 2 <| String.fromInt <| Time.toMillis zone posix)
         -- @TODO use the timezone lookup in future
-        ++ " UTC"
+        ++ formatTimezone zone posix
+
+
+formatTimezone : Time.Zone -> Time.Posix -> String
+formatTimezone zone posix =
+    let
+        offset =
+            toOffset zone posix // 60
+
+        sign =
+            if offset < 0 then
+                "-"
+
+            else
+                "+"
+    in
+    " UTC" ++ sign ++ String.fromInt offset
 
 
 monthToInt : Time.Month -> Int


### PR DESCRIPTION
## Purpose

Format dates to localtime and display the UTC offset

## Changes

- Read the timezone at initialization.
- Forward the timezone anywhere a date is being displayed.
- Display the UTC offset.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.