### PR TITLE
Add validation of transaction lookup string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased changes
 
+### Added
+- Validate transaction hash when using the transaction lookup page.
+
 ## [1.0.2] - (2021-10-04)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "concordium-dashboard",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Concordium Network Dashboard",
   "main": "dashboard-backend.js",
   "engines": {

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -381,12 +381,12 @@ onRouteInit page model =
             , Api.getBlockInfo hash (ExplorerMsg << Explorer.ReceivedBlockResponse)
             )
 
-        Route.Lookup (Just txHash) ->
+        Route.Lookup hash ->
             let
-                lookupModel =
-                    model.lookupModel
+                ( newModel, cmd ) =
+                    Lookup.onRouteInit hash model.lookupModel
             in
-            ( { model | lookupModel = { lookupModel | searchTextValue = txHash } }, Api.getTransactionStatus txHash (LookupMsg << Lookup.ReceivedTransactionStatus) )
+            ( { model | lookupModel = newModel }, Cmd.map LookupMsg cmd )
 
         _ ->
             ( model, Cmd.none )

--- a/src/elm/Types.elm
+++ b/src/elm/Types.elm
@@ -379,13 +379,13 @@ transactionHashErrorToString : TransactionHashError -> String
 transactionHashErrorToString error =
     case error of
         InvalidLength ->
-            "A transaction hash must be of lenght 64."
+            "A transaction hash must be of length 64."
 
         InvalidHexEncoding ->
-            "A transaction hash can only consist of digits and lowercase letters from 'a', to 'f'."
+            "A transaction hash can only consist of digits and lowercase letters from 'a' to 'f'."
 
 
-{-| Validate a string to be a transaction hash, returns nothing if the string is valid
+{-| Check whether a string is a valid transaction hash. Returns Nothing if it is valid.
 -}
 validateTransactionHash : String -> Maybe TransactionHashError
 validateTransactionHash str =

--- a/src/elm/Types.elm
+++ b/src/elm/Types.elm
@@ -364,3 +364,36 @@ type alias BlockHash =
 
 type alias TxHash =
     String
+
+
+{-| Error type for when validating a string as a transaction hash
+-}
+type TransactionHashError
+    = InvalidLength
+    | InvalidHexEncoding
+
+
+{-| Convert error to a readable error message
+-}
+transactionHashErrorToString : TransactionHashError -> String
+transactionHashErrorToString error =
+    case error of
+        InvalidLength ->
+            "A transaction hash must be of lenght 64."
+
+        InvalidHexEncoding ->
+            "A transaction hash can only consist of digits and lowercase letters from 'a', to 'f'."
+
+
+{-| Validate a string to be a transaction hash, returns nothing if the string is valid
+-}
+validateTransactionHash : String -> Maybe TransactionHashError
+validateTransactionHash str =
+    if String.length str /= 64 then
+        Just InvalidLength
+
+    else if String.any (not << Char.isHexDigit) str then
+        Just InvalidHexEncoding
+
+    else
+        Nothing


### PR DESCRIPTION
## Purpose

Add validation of user input when using transaction lookup.
Closes #38.

## Changes

- Add function for validating a transaction hash.
  Validation includes checking for hex string length is 64 characters and checking that every character is a hex-digit.
- Display error message when searching for invalid transaction hash.
- Move Lookup page initialization logic into `Lookup.elm`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
