### PR TITLE
Jenkins: Use library function for ECR login

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,12 +1,11 @@
+@Library('concordium-pipelines') _
 pipeline {
     agent any
-
     environment {
         ecr_repo_domain = '192549843005.dkr.ecr.eu-west-1.amazonaws.com'
         image_repo = "${ecr_repo_domain}/concordium/network-dashboard"
         image_name = "${image_repo}:${image_tag}"
     }
-
     stages {
         stage('ecr-login') {
             steps {


### PR DESCRIPTION
## Purpose

Ensure that all pipelines use the shared Jenkins library function `ecrLogin`. This removes a lot of noise from the pipelines and ensures that a consistent method is used.

## Changes

Jenkinsfile is migrated to use `ecrLogin`.