### PR TITLE
Ignore old nodes in computing summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased changes
 
+- Add a parameter to ignore older node versions in statistics calculations.
+
 ## [1.0.3] - (2021-11-22)
 
 ### Added

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ pipeline {
         ecr_repo_domain = '192549843005.dkr.ecr.eu-west-1.amazonaws.com'
         image_repo = "${ecr_repo_domain}/concordium/network-dashboard"
         image_name = "${image_repo}:${image_tag}"
+        stats_version = "${minimum_node_version}"
     }
     stages {
         stage('ecr-login') {
@@ -15,7 +16,7 @@ pipeline {
         stage('build') {
             steps {
                 sh '''\
-                  docker build -t "${image_name}" -f k8s.Dockerfile .
+                  docker build --build-arg stats_version=${stats_version} --label stats_version=${stats_version} -t "${image_name}" -f k8s.Dockerfile .
                   docker push "${image_name}"
                 '''
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
         ecr_repo_domain = '192549843005.dkr.ecr.eu-west-1.amazonaws.com'
         image_repo = "${ecr_repo_domain}/concordium/network-dashboard"
         image_name = "${image_repo}:${image_tag}"
-        stats_version = "${minimum_node_version}"
+        min_version_included_in_stats = "${minimum_node_version}"
     }
     stages {
         stage('ecr-login') {
@@ -16,7 +16,7 @@ pipeline {
         stage('build') {
             steps {
                 sh '''\
-                  docker build --build-arg stats_version=${stats_version} --label stats_version=${stats_version} -t "${image_name}" -f k8s.Dockerfile .
+                  docker build --build-arg min_version_included_in_stats=${min_version_included_in_stats} --label min_version_included_in_stats=${min_version_included_in_stats} -t "${image_name}" -f k8s.Dockerfile .
                   docker push "${image_name}"
                 '''
             }

--- a/README.md
+++ b/README.md
@@ -28,16 +28,20 @@ The development server will proxy some requests to either of these and must be p
 
 To use the development server with a local middleware and collector backend run:
 ```
-CONCORDIUM_MIDDLEWARE_URL='http://localhost:8081' CONCORDIUM_COLLECTOR_BACKEND_URL='http://localhost:12000' npm run dev
+STATS_VERSION=3 CONCORDIUM_MIDDLEWARE_URL='http://localhost:8081' CONCORDIUM_COLLECTOR_BACKEND_URL='http://localhost:12000' npm run dev
 ```
 Then open the app (http://localhost:3001) in a browser. The app refreshes automatically when files are changed.
+
+The `STATS_VERSION` variable specifies the minimal version of the node that
+allows it to be included in the calculation of summaries at the top of the
+page, e.g., current finalized height.
 
 
 **Mainnet**
 
 To use the development server with the Mainnet middleware and collector backend run:
 ```
-npm run dev:mainnet
+STATS_VERSION=3 npm run dev:mainnet
 ```
 Then open the app (http://localhost:3001) in a browser. The app refreshes automatically when files are changed.
 
@@ -45,7 +49,7 @@ Then open the app (http://localhost:3001) in a browser. The app refreshes automa
 
 To use the development server with the Testnet middleware and collector backend run:
 ```
-npm run dev:testnet
+STATS_VERSION=3 npm run dev:testnet
 ```
 Then open the app (http://localhost:3001) in a browser. The app refreshes automatically when files are changed.
 
@@ -55,14 +59,14 @@ _Stagenet is for internal use and requires VPN to access._
 
 To use the development server with the Stagenet middleware and collector backend run:
 ```
-npm run dev:stagenet
+STATS_VERSION=3 npm run dev:stagenet
 ```
 Then open the app (http://localhost:3001) in a browser. The app refreshes automatically when files are changed.
 
 
 Other common build/run targets include:
 
-- `npm run build` - Build the app in production mode and put it into `./dist`.
+- `STATS_VERSION=3 npm run build` - Build the app in production mode and put it into `./dist`.
 - `npm run formatcheck` - Checks the elm formatting.
 
 See the `script` section of `package.json` for all targets as well as their definitions.

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ The development server will proxy some requests to either of these and must be p
 
 To use the development server with a local middleware and collector backend run:
 ```
-STATS_VERSION=3 CONCORDIUM_MIDDLEWARE_URL='http://localhost:8081' CONCORDIUM_COLLECTOR_BACKEND_URL='http://localhost:12000' npm run dev
+MIN_VERSION_INCLUDED_IN_STATS=3 CONCORDIUM_MIDDLEWARE_URL='http://localhost:8081' CONCORDIUM_COLLECTOR_BACKEND_URL='http://localhost:12000' npm run dev
 ```
 Then open the app (http://localhost:3001) in a browser. The app refreshes automatically when files are changed.
 
-The `STATS_VERSION` variable specifies the minimal version of the node that
+The `MIN_VERSION_INCLUDED_IN_STATS` variable specifies the minimal version of the node that
 allows it to be included in the calculation of summaries at the top of the
 page, e.g., current finalized height.
 
@@ -41,7 +41,7 @@ page, e.g., current finalized height.
 
 To use the development server with the Mainnet middleware and collector backend run:
 ```
-STATS_VERSION=3 npm run dev:mainnet
+MIN_VERSION_INCLUDED_IN_STATS=3 npm run dev:mainnet
 ```
 Then open the app (http://localhost:3001) in a browser. The app refreshes automatically when files are changed.
 
@@ -49,7 +49,7 @@ Then open the app (http://localhost:3001) in a browser. The app refreshes automa
 
 To use the development server with the Testnet middleware and collector backend run:
 ```
-STATS_VERSION=3 npm run dev:testnet
+MIN_VERSION_INCLUDED_IN_STATS=3 npm run dev:testnet
 ```
 Then open the app (http://localhost:3001) in a browser. The app refreshes automatically when files are changed.
 
@@ -59,14 +59,14 @@ _Stagenet is for internal use and requires VPN to access._
 
 To use the development server with the Stagenet middleware and collector backend run:
 ```
-STATS_VERSION=3 npm run dev:stagenet
+MIN_VERSION_INCLUDED_IN_STATS=3 npm run dev:stagenet
 ```
 Then open the app (http://localhost:3001) in a browser. The app refreshes automatically when files are changed.
 
 
 Other common build/run targets include:
 
-- `STATS_VERSION=3 npm run build` - Build the app in production mode and put it into `./dist`.
+- `MIN_VERSION_INCLUDED_IN_STATS=3 npm run build` - Build the app in production mode and put it into `./dist`.
 - `npm run formatcheck` - Checks the elm formatting.
 
 See the `script` section of `package.json` for all targets as well as their definitions.

--- a/k8s.Dockerfile
+++ b/k8s.Dockerfile
@@ -1,5 +1,13 @@
 FROM node:14 as build
 
+# Minimum node version to include in summary calculations.
+ARG stats_version
+
+# Check that STATS_VERSION was indeed supplied
+RUN : "${stats_version:?Must be set and non-empty.}"
+
+ENV STATS_VERSION=${stats_version}
+
 # https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 # USER node

--- a/k8s.Dockerfile
+++ b/k8s.Dockerfile
@@ -1,12 +1,12 @@
 FROM node:14 as build
 
 # Minimum node version to include in summary calculations.
-ARG stats_version
+ARG min_version_included_in_stats
 
-# Check that STATS_VERSION was indeed supplied
-RUN : "${stats_version:?Must be set and non-empty.}"
+# Check that MIN_VERSION_INCLUDED_IN_STATS was indeed supplied
+RUN : "${min_version_included_in_stats:?Must be set and non-empty.}"
 
-ENV STATS_VERSION=${stats_version}
+ENV MIN_VERSION_INCLUDED_IN_STATS=${min_version_included_in_stats}
 
 # https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "concordium-dashboard",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Concordium Network Dashboard",
   "main": "dashboard-backend.js",
   "engines": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -12,6 +12,7 @@ const app = Elm.Main.init({
     },
     isProduction: __PRODUCTION__,
     version: __VERSION__,
+    statsVersion: __STATS_VERSION__,
     showCookieConsentBanner: loadCookieConsentChoice() === undefined,
   },
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -12,7 +12,7 @@ const app = Elm.Main.init({
     },
     isProduction: __PRODUCTION__,
     version: __VERSION__,
-    statsVersion: __STATS_VERSION__,
+    minVersionIncludedInStats: __MIN_VERSION_INCLUDED_IN_STATS__,
     showCookieConsentBanner: loadCookieConsentChoice() === undefined,
   },
 });

--- a/src/elm/Context.elm
+++ b/src/elm/Context.elm
@@ -16,7 +16,7 @@ type alias Context a =
             | key : Key
             , time : Posix
             , window : Window
-            , statsVersion : String
+            , minVersionIncludedInStats : String
         }
 
 

--- a/src/elm/Context.elm
+++ b/src/elm/Context.elm
@@ -16,6 +16,7 @@ type alias Context a =
             | key : Key
             , time : Posix
             , window : Window
+            , statsVersion : String
         }
 
 

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -46,6 +46,10 @@ type alias Flags =
     , isProduction : Bool
     , version : Version
     , showCookieConsentBanner : Bool
+
+    -- Minimum version of the node that will be taken
+    -- into account when computing statistics
+    , statsVersion : Version
     }
 
 
@@ -71,6 +75,7 @@ type alias Model =
     , config : Config
     , window : { width : Int, height : Int }
     , version : Version
+    , statsVersion : Version
     , showCookieConsentBanner : Bool
     , palette : Palette Element.Color
     , colorMode : ColorMode
@@ -134,6 +139,7 @@ init flags url key =
                 , time = Time.millisToPosix 0
                 , timezone = Time.utc
                 , config = cfg
+                , statsVersion = flags.statsVersion
                 , version = flags.version
                 , showCookieConsentBanner = flags.showCookieConsentBanner
                 , window = flags.window

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -49,7 +49,7 @@ type alias Flags =
 
     -- Minimum version of the node that will be taken
     -- into account when computing statistics
-    , statsVersion : Version
+    , minVersionIncludedInStats : Version
     }
 
 
@@ -75,7 +75,7 @@ type alias Model =
     , config : Config
     , window : { width : Int, height : Int }
     , version : Version
-    , statsVersion : Version
+    , minVersionIncludedInStats : Version
     , showCookieConsentBanner : Bool
     , palette : Palette Element.Color
     , colorMode : ColorMode
@@ -139,7 +139,7 @@ init flags url key =
                 , time = Time.millisToPosix 0
                 , timezone = Time.utc
                 , config = cfg
-                , statsVersion = flags.statsVersion
+                , minVersionIncludedInStats = flags.minVersionIncludedInStats
                 , version = flags.version
                 , showCookieConsentBanner = flags.showCookieConsentBanner
                 , window = flags.window

--- a/src/elm/Network.elm
+++ b/src/elm/Network.elm
@@ -253,7 +253,7 @@ viewSummaryWidgets ctx remoteNodes =
                             (\nodesDict ->
                                 let
                                     compatibleNodes =
-                                        Dict.filter (\_ node -> node.client >= ctx.statsVersion) nodesDict
+                                        Dict.filter (\_ -> allowedNodeVersion ctx) nodesDict
                                 in
                                 majorityStatFor
                                     (\node ->
@@ -278,7 +278,7 @@ viewSummaryWidgets ctx remoteNodes =
                                 let
                                     nodes =
                                         Dict.values nodeDict
-                                            |> List.filter (\node -> node.client >= ctx.statsVersion)
+                                            |> List.filter (allowedNodeVersion ctx)
                                 in
                                 nodes
                                     |> List.map .finalizedBlockHeight
@@ -310,7 +310,7 @@ viewSummaryWidgets ctx remoteNodes =
                             (\nodesDict ->
                                 let
                                     compatibleNodes =
-                                        Dict.filter (\_ node -> node.client >= ctx.statsVersion) nodesDict
+                                        Dict.filter (\_ -> allowedNodeVersion ctx) nodesDict
                                 in
                                 String.fromInt <| round (majorityStatFor .bestBlockHeight -1 compatibleNodes)
                             )
@@ -329,7 +329,7 @@ viewSummaryWidgets ctx remoteNodes =
                             (\nodesDict ->
                                 let
                                     compatibleNodes =
-                                        Dict.filter (\_ node -> node.client >= ctx.statsVersion) nodesDict
+                                        Dict.filter (\_ -> allowedNodeVersion ctx) nodesDict
                                 in
                                 String.fromInt <| round (majorityStatFor .finalizedBlockHeight -1 compatibleNodes)
                             )
@@ -349,7 +349,7 @@ viewSummaryWidgets ctx remoteNodes =
                             (\nodesDict ->
                                 let
                                     compatibleNodes =
-                                        Dict.filter (\_ node -> node.client >= ctx.statsVersion) nodesDict
+                                        Dict.filter (\_ -> allowedNodeVersion ctx) nodesDict
                                 in
                                 averageStatSecondsFor .blockArrivePeriodEMA compatibleNodes
                             )
@@ -366,7 +366,7 @@ viewSummaryWidgets ctx remoteNodes =
                             (\nodesDict ->
                                 let
                                     compatibleNodes =
-                                        Dict.filter (\_ node -> node.client >= ctx.statsVersion) nodesDict
+                                        Dict.filter (\_ -> allowedNodeVersion ctx) nodesDict
                                 in
                                 averageStatSecondsFor .finalizationPeriodEMA compatibleNodes
                             )
@@ -382,6 +382,16 @@ viewSummaryWidgets ctx remoteNodes =
 nodePeersOnly : Dict Host NetworkNode -> Dict Host NetworkNode
 nodePeersOnly nodes =
     nodes |> Dict.filter (\_ n -> n.peerType == "Node")
+
+
+
+-- Check whether the client version is recent enough.
+-- NB: This will only work until we have node version 10, after that it needs to be revised.
+
+
+allowedNodeVersion : { ctx | minVersionIncludedInStats : String } -> { a | client : String } -> Bool
+allowedNodeVersion ctx node =
+    node.client >= ctx.minVersionIncludedInStats
 
 
 {-| For the given node attribute, finds majority value across all nodes

--- a/src/elm/Network.elm
+++ b/src/elm/Network.elm
@@ -250,7 +250,11 @@ viewSummaryWidgets ctx remoteNodes =
                   , icon = Icons.lastBlock iconSize
                   , value =
                         RemoteData.map
-                            (\nodes ->
+                            (\nodesDict ->
+                                let
+                                    compatibleNodes =
+                                        Dict.filter (\_ node -> node.client >= ctx.statsVersion) nodesDict
+                                in
                                 majorityStatFor
                                     (\node ->
                                         Maybe.withDefault "" node.bestArrivedTime
@@ -259,7 +263,7 @@ viewSummaryWidgets ctx remoteNodes =
                                             |> asSecondsAgo ctx.time
                                     )
                                     ""
-                                    nodes
+                                    compatibleNodes
                             )
                             remoteNodes
                   , subvalue = Nothing
@@ -274,6 +278,7 @@ viewSummaryWidgets ctx remoteNodes =
                                 let
                                     nodes =
                                         Dict.values nodeDict
+                                            |> List.filter (\node -> node.client >= ctx.statsVersion)
                                 in
                                 nodes
                                     |> List.map .finalizedBlockHeight
@@ -302,7 +307,13 @@ viewSummaryWidgets ctx remoteNodes =
                             (Palette.uiToColor ctx.palette.c2)
                   , value =
                         RemoteData.map
-                            (\nodes -> String.fromInt <| round (majorityStatFor .bestBlockHeight -1 nodes))
+                            (\nodesDict ->
+                                let
+                                    compatibleNodes =
+                                        Dict.filter (\_ node -> node.client >= ctx.statsVersion) nodesDict
+                                in
+                                String.fromInt <| round (majorityStatFor .bestBlockHeight -1 compatibleNodes)
+                            )
                             remoteNodes
                   , subvalue = Nothing
                   }
@@ -315,7 +326,13 @@ viewSummaryWidgets ctx remoteNodes =
                             (Palette.uiToColor ctx.palette.c2)
                   , value =
                         RemoteData.map
-                            (\nodes -> String.fromInt <| round (majorityStatFor .finalizedBlockHeight -1 nodes))
+                            (\nodesDict ->
+                                let
+                                    compatibleNodes =
+                                        Dict.filter (\_ node -> node.client >= ctx.statsVersion) nodesDict
+                                in
+                                String.fromInt <| round (majorityStatFor .finalizedBlockHeight -1 compatibleNodes)
+                            )
                             remoteNodes
                   , subvalue = Nothing
                   }
@@ -329,7 +346,13 @@ viewSummaryWidgets ctx remoteNodes =
                   , icon = Icons.lastBlockEMA iconSize
                   , value =
                         RemoteData.map
-                            (\nodes -> averageStatSecondsFor .blockArrivePeriodEMA nodes)
+                            (\nodesDict ->
+                                let
+                                    compatibleNodes =
+                                        Dict.filter (\_ node -> node.client >= ctx.statsVersion) nodesDict
+                                in
+                                averageStatSecondsFor .blockArrivePeriodEMA compatibleNodes
+                            )
                             remoteNodes
                   , subvalue =
                         Nothing
@@ -340,7 +363,13 @@ viewSummaryWidgets ctx remoteNodes =
                   , icon = Icons.lastFinalizedBlockEMA iconSize
                   , value =
                         RemoteData.map
-                            (\nodes -> averageStatSecondsFor .finalizationPeriodEMA nodes)
+                            (\nodesDict ->
+                                let
+                                    compatibleNodes =
+                                        Dict.filter (\_ node -> node.client >= ctx.statsVersion) nodesDict
+                                in
+                                averageStatSecondsFor .finalizationPeriodEMA compatibleNodes
+                            )
                             remoteNodes
                   , subvalue =
                         Nothing

--- a/src/elm/Network.elm
+++ b/src/elm/Network.elm
@@ -384,11 +384,9 @@ nodePeersOnly nodes =
     nodes |> Dict.filter (\_ n -> n.peerType == "Node")
 
 
-
--- Check whether the client version is recent enough.
--- NB: This will only work until we have node version 10, after that it needs to be revised.
-
-
+{-| Check whether the client version is recent enough.
+NB: This will only work until we have node version 10, after that it needs to be revised.
+-}
 allowedNodeVersion : { ctx | minVersionIncludedInStats : String } -> { a | client : String } -> Bool
 allowedNodeVersion ctx node =
     node.client >= ctx.minVersionIncludedInStats

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,5 +1,5 @@
 declare const __VERSION__: string;
-declare const __STATS_VERSION__: string;
+declare const __MIN_VERSION_INCLUDED_IN_STATS__: string;
 declare const __ANALYTICS_ID__: string;
 declare const __PRODUCTION__: boolean;
 // Defined globally in index.ejs

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,4 +1,5 @@
 declare const __VERSION__: string;
+declare const __STATS_VERSION__: string;
 declare const __ANALYTICS_ID__: string;
 declare const __PRODUCTION__: boolean;
 // Defined globally in index.ejs

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,7 +62,7 @@ module.exports = {
     }),
     new webpack.DefinePlugin({
       __VERSION__: JSON.stringify(packageJson.version),
-      __STATS_VERSION__: JSON.stringify(process.env.STATS_VERSION),
+      __MIN_VERSION_INCLUDED_IN_STATS__: JSON.stringify(process.env.MIN_VERSION_INCLUDED_IN_STATS),
       __ANALYTICS_ID__: JSON.stringify(analyticsId),
       __PRODUCTION__: isProduction.toString(),
     }),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,6 +62,7 @@ module.exports = {
     }),
     new webpack.DefinePlugin({
       __VERSION__: JSON.stringify(packageJson.version),
+      __STATS_VERSION__: JSON.stringify(process.env.STATS_VERSION),
       __ANALYTICS_ID__: JSON.stringify(analyticsId),
       __PRODUCTION__: isProduction.toString(),
     }),


### PR DESCRIPTION
## Purpose

Fixes #88 

## Changes

Ignore old versions in statistics calculations. Introduces a new environment variable `STATS_VERSION`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.