### PR TITLE
Display normalized EUR/CCD exchange rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased changes
+# Unreleased changes
+
+- Display the CCD/EUR exchange rate normalized to 1 EUR.
+- Correctly display the effective time of updates with immediate effect.
+
+## [1.0.4]
 
 - Add a parameter to ignore older node versions in statistics calculations.
-- Display the CCD/EUR exchange rate normalized to 1 EUR.
 
 ## [1.0.3] - (2021-11-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased changes
 
 - Add a parameter to ignore older node versions in statistics calculations.
+- Display the CCD/EUR exchange rate normalized to 1 EUR.
 
 ## [1.0.3] - (2021-11-22)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "concordium-dashboard",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Concordium Network Dashboard",
   "main": "dashboard-backend.js",
   "engines": {

--- a/src/elm/Explorer/View.elm
+++ b/src/elm/Explorer/View.elm
@@ -1918,9 +1918,8 @@ viewEventUpdateEnqueuedDetails ctx event =
             row [ width fill ]
                 [ text <|
                     "Update the CCD to Euro conversion rate to "
-                        ++ String.fromInt microCCDPerEuro.denominator
-                        ++ " EUR = "
-                        ++ (T.amountToString <| T.amountFromInt microCCDPerEuro.numerator)
+                        ++ "1 EUR = "
+                        ++ (T.amountToString <| T.amountFromInt (microCCDPerEuro.numerator // microCCDPerEuro.denominator))
                 ]
 
         FoundationAccountPayload foundationAccount ->

--- a/src/elm/Explorer/View.elm
+++ b/src/elm/Explorer/View.elm
@@ -936,7 +936,14 @@ viewUpdates theme timezone updates =
         viewUpdate : EventUpdateEnqueued -> Element Msg
         viewUpdate update =
             updateRow
-                (el [ Font.color theme.palette.fg1 ] <| text <| TimeHelpers.formatTime timezone update.effectiveTime)
+                (el [ Font.color theme.palette.fg1 ] <|
+                    text <|
+                        if (Time.posixToMillis <| update.effectiveTime) == 0 then
+                            "immediate"
+
+                        else
+                            TimeHelpers.formatTime timezone update.effectiveTime
+                )
                 (viewEventUpdateEnqueuedDetails theme update)
     in
     if List.isEmpty allQueuedUpdates then
@@ -1811,7 +1818,14 @@ viewTransactionEvent ctx timezone txEvent =
         TransactionEventUpdateEnqueued event ->
             { content =
                 eventElem
-                    [ text <| "Update enqueued to take effect " ++ TimeHelpers.formatTime timezone event.effectiveTime
+                    [ text <|
+                        "Update enqueued to take effect "
+                            ++ (if (Time.posixToMillis <| event.effectiveTime) == 0 then
+                                    "immediately"
+
+                                else
+                                    TimeHelpers.formatTime timezone event.effectiveTime
+                               )
                     ]
             , details =
                 Just <|


### PR DESCRIPTION
## Purpose

The CCD/EUR exchange rate should be shown as "1 EUR = X CCD" in update event list. 

Closes #94 

## Changes

The exchange rate is received from the CCD2EUR services as a fraction, where the nominator stands for microCCDs, and the denominator stands for euro. To display the exchange rate as "1 EUR = X CCD", one takes the whole part of the nominator divided by the denominator. There's no loss of precision because we assume microCCDs to be the smallest unit of CCD.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
