### PR TITLE
Added support for protocol V4, including delegation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 - Display the CCD/EUR exchange rate normalized to 1 EUR.
 - Correctly display the effective time of updates with immediate effect.
 - Display the ConfigureBaker and ConfigureDelegation transactions
-- Display pool (including L-pool) and foundation block rewards
+- Display pool, passive delegation and foundation block rewards
 
 ## [1.0.4]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 - Display the CCD/EUR exchange rate normalized to 1 EUR.
 - Correctly display the effective time of updates with immediate effect.
+- Display the ConfigureBaker and ConfigureDelegation transactions
+- Display pool (including L-pool) and foundation block rewards
 
 ## [1.0.4]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "concordium-dashboard",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Concordium Network Dashboard",
   "main": "dashboard-backend.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "concordium-dashboard",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Concordium Network Dashboard",
   "main": "dashboard-backend.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "concordium-dashboard",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Concordium Network Dashboard",
   "main": "dashboard-backend.js",
   "engines": {

--- a/src/elm/Explorer/Request.elm
+++ b/src/elm/Explorer/Request.elm
@@ -167,7 +167,7 @@ chainParametersDecoderV0 =
         |> required "microGTUPerEuro" relationDecoder
         |> required "foundationAccountIndex" D.int
         |> required "accountCreationLimit" D.int
-        |> required "bakerCooldownEpochs" D.int   
+        |> required "bakerCooldownEpochs" D.int
         |> required "electionDifficulty" D.float
         |> required "euroPerEnergy" relationDecoder
         |> required "minimumThresholdForBaking" T.decodeAmount

--- a/src/elm/Explorer/Request.elm
+++ b/src/elm/Explorer/Request.elm
@@ -282,7 +282,7 @@ type alias BlockAccrueReward =
     }
 
 type alias PaydayPoolReward =
-    { poolOwner : T.BakerId
+    { poolOwner : Maybe T.BakerId
     , transactionFees : T.Amount
     , bakerReward : T.Amount
     , finalizationReward : T.Amount
@@ -352,7 +352,7 @@ specialEventDecoder =
 
                 "PaydayPoolReward" ->
                     D.succeed PaydayPoolReward
-                      |> required "poolOwner" D.int
+                      |> required "poolOwner" (D.nullable D.int)
                       |> required "transactionFees" T.decodeAmount
                       |> required "bakerReward" T.decodeAmount
                       |> required "finalizationReward" T.decodeAmount

--- a/src/elm/Explorer/Request.elm
+++ b/src/elm/Explorer/Request.elm
@@ -14,7 +14,6 @@ import Transaction.Summary exposing (..)
 import Types as T
 
 
-
 -- BlockSummary
 
 
@@ -63,12 +62,11 @@ blockSummaryDecoder =
         |> required "specialEvents" (D.list specialEventDecoder)
         |> required "transactionSummaries" (D.list transactionSummaryDecoder)
         |> optional "finalizationData" (D.nullable finalizationDataDecoder) Nothing
-        |> required "updates" updatesDecoder
-
-
+        |> required "updates" (D.oneOf [updatesDecoderV1, updatesDecoderV0])
 
 -- Updates
 
+type ChainParameters = CPV0 ChainParametersV0 | CPV1 ChainParametersV1
 
 type alias Updates =
     { chainParameters : ChainParameters
@@ -76,8 +74,18 @@ type alias Updates =
     , updateQueues : UpdateQueues
     }
 
-
-type alias ChainParameters =
+type alias ChainParametersV0 =
+    { rewardParameters : RewardParameters
+    , microCCDPerEuro : Relation
+    , foundationAccountIndex : Int
+    , accountCreationLimit : Int
+    , bakerCooldownEpochs : Int
+    , electionDifficulty : Float
+    , euroPerEnergy : Relation
+    , minimumThresholdForBaking : T.Amount
+    }
+    
+type alias ChainParametersV1 =
     { rewardParameters : RewardParameters
     , microCCDPerEuro : Relation
     , foundationAccountIndex : Int
@@ -138,18 +146,36 @@ type alias UpdateQueueItem a =
     , update : a
     }
 
-
-updatesDecoder : D.Decoder Updates
-updatesDecoder =
+updatesDecoderV0 : D.Decoder Updates
+updatesDecoderV0 =
     D.succeed Updates
-        |> required "chainParameters" chainParametersDecoder
+        |> required "chainParameters" chainParametersDecoderV0
+        |> required "keys" updateKeysCollectionDecoder
+        |> required "updateQueues" updateQueuesDecoder
+    
+updatesDecoderV1 : D.Decoder Updates
+updatesDecoderV1 =
+    D.succeed Updates
+        |> required "chainParameters" chainParametersDecoderV1
         |> required "keys" updateKeysCollectionDecoder
         |> required "updateQueues" updateQueuesDecoder
 
-
-chainParametersDecoder : D.Decoder ChainParameters
-chainParametersDecoder =
-    D.succeed ChainParameters
+chainParametersDecoderV0 : D.Decoder ChainParameters
+chainParametersDecoderV0 =
+    D.succeed ChainParametersV0
+        |> required "rewardParameters" rewardParametersDecoder
+        |> required "microGTUPerEuro" relationDecoder
+        |> required "foundationAccountIndex" D.int
+        |> required "accountCreationLimit" D.int
+        |> required "bakerCooldownEpochs" D.int   
+        |> required "electionDifficulty" D.float
+        |> required "euroPerEnergy" relationDecoder
+        |> required "minimumThresholdForBaking" T.decodeAmount
+        |> D.map CPV0
+           
+chainParametersDecoderV1 : D.Decoder ChainParameters
+chainParametersDecoderV1 =
+    D.succeed ChainParametersV1
         |> required "rewardParameters" rewardParametersDecoder
         |> required "microGTUPerEuro" relationDecoder
         |> required "foundationAccountIndex" D.int
@@ -169,20 +195,21 @@ chainParametersDecoder =
         |> required "leverageBound" relationDecoder
         |> required "rewardPeriodLength" D.int
         |> required "mintPerPayday" D.float
-
+        |> D.map CPV1
 
 rewardParametersDecoder : D.Decoder RewardParameters
 rewardParametersDecoder =
     D.succeed RewardParameters
-        |> required "mintDistribution" mintDistributionDecoder
+        |> required "mintDistribution" (D.oneOf [ mintDistributionV1Decoder
+                                                , mintDistributionV0Decoder] )
         |> required "transactionFeeDistribution" transactionFeeDistributionDecoder
         |> required "gASRewards" gasRewardsDecoder
-
 
 updateQueuesDecoder : D.Decoder UpdateQueues
 updateQueuesDecoder =
     D.succeed UpdateQueues
-        |> required "mintDistribution" (updateQueueDecoder mintDistributionDecoder)
+        |> required "mintDistribution" (updateQueueDecoder (D.oneOf [ mintDistributionV1Decoder
+                                                                    , mintDistributionV0Decoder ]))
         |> required "transactionFeeDistribution" (updateQueueDecoder transactionFeeDistributionDecoder)
         |> required "rootKeys" (updateQueueDecoder higherLevelKeysDecoder)
         |> required "level1Keys" (updateQueueDecoder higherLevelKeysDecoder)
@@ -195,9 +222,13 @@ updateQueuesDecoder =
         |> required "euroPerEnergy" (updateQueueDecoder relationDecoder)
         |> required "addAnonymityRevoker" (updateQueueDecoder arDecoder)
         |> required "addIdentityProvider" (updateQueueDecoder ipDecoder)
-        |> required "poolParameters" (updateQueueDecoder poolParametersDecoder)
-        |> required "cooldownParameters" (updateQueueDecoder cooldownParametersDecoder)
-        |> required "timeParameters" (updateQueueDecoder timeParametersDecoder)       
+        |> optional "poolParameters" (updateQueueDecoder (D.oneOf [ poolParametersV1Decoder
+                                                                 , poolParametersV0Decoder ]))
+           { nextSequenceNumber = 0, queue = [] }
+        |> optional "cooldownParameters" (updateQueueDecoder (D.oneOf [ cooldownParametersV1Decoder
+                                                                      , cooldownParametersV0Decoder]))
+           { nextSequenceNumber = 0, queue = [] }
+        |> optional "timeParameters" (updateQueueDecoder timeParametersDecoder) { nextSequenceNumber = 0, queue = [] }
 
 
 updateQueueDecoder : D.Decoder a -> D.Decoder (UpdateQueue a)

--- a/src/elm/Explorer/Request.elm
+++ b/src/elm/Explorer/Request.elm
@@ -14,6 +14,7 @@ import Transaction.Summary exposing (..)
 import Types as T
 
 
+
 -- BlockSummary
 
 
@@ -62,17 +63,24 @@ blockSummaryDecoder =
         |> required "specialEvents" (D.list specialEventDecoder)
         |> required "transactionSummaries" (D.list transactionSummaryDecoder)
         |> optional "finalizationData" (D.nullable finalizationDataDecoder) Nothing
-        |> required "updates" (D.oneOf [updatesDecoderV1, updatesDecoderV0])
+        |> required "updates" (D.oneOf [ updatesDecoderV1, updatesDecoderV0 ])
+
+
 
 -- Updates
 
-type ChainParameters = CPV0 ChainParametersV0 | CPV1 ChainParametersV1
+
+type ChainParameters
+    = CPV0 ChainParametersV0
+    | CPV1 ChainParametersV1
+
 
 type alias Updates =
     { chainParameters : ChainParameters
     , keyCollection : UpdateKeysCollection
     , updateQueues : UpdateQueues
     }
+
 
 type alias ChainParametersV0 =
     { rewardParameters : RewardParameters
@@ -84,7 +92,8 @@ type alias ChainParametersV0 =
     , euroPerEnergy : Relation
     , minimumThresholdForBaking : T.Amount
     }
-    
+
+
 type alias ChainParametersV1 =
     { rewardParameters : RewardParameters
     , microCCDPerEuro : Relation
@@ -131,7 +140,7 @@ type alias UpdateQueues =
     , identityProvider : UpdateQueue IdentityProviderInfo
     , poolParameters : UpdateQueue PoolParameters
     , cooldownParameters : UpdateQueue CooldownParameters
-    , timeParameters : UpdateQueue TimeParameters    
+    , timeParameters : UpdateQueue TimeParameters
     }
 
 
@@ -146,19 +155,22 @@ type alias UpdateQueueItem a =
     , update : a
     }
 
+
 updatesDecoderV0 : D.Decoder Updates
 updatesDecoderV0 =
     D.succeed Updates
         |> required "chainParameters" chainParametersDecoderV0
         |> required "keys" updateKeysCollectionDecoder
         |> required "updateQueues" updateQueuesDecoder
-    
+
+
 updatesDecoderV1 : D.Decoder Updates
 updatesDecoderV1 =
     D.succeed Updates
         |> required "chainParameters" chainParametersDecoderV1
         |> required "keys" updateKeysCollectionDecoder
         |> required "updateQueues" updateQueuesDecoder
+
 
 chainParametersDecoderV0 : D.Decoder ChainParameters
 chainParametersDecoderV0 =
@@ -172,7 +184,8 @@ chainParametersDecoderV0 =
         |> required "euroPerEnergy" relationDecoder
         |> required "minimumThresholdForBaking" T.decodeAmount
         |> D.map CPV0
-           
+
+
 chainParametersDecoderV1 : D.Decoder ChainParameters
 chainParametersDecoderV1 =
     D.succeed ChainParametersV1
@@ -197,19 +210,31 @@ chainParametersDecoderV1 =
         |> required "mintPerPayday" D.float
         |> D.map CPV1
 
+
 rewardParametersDecoder : D.Decoder RewardParameters
 rewardParametersDecoder =
     D.succeed RewardParameters
-        |> required "mintDistribution" (D.oneOf [ mintDistributionV1Decoder
-                                                , mintDistributionV0Decoder] )
+        |> required "mintDistribution"
+            (D.oneOf
+                [ mintDistributionV1Decoder
+                , mintDistributionV0Decoder
+                ]
+            )
         |> required "transactionFeeDistribution" transactionFeeDistributionDecoder
         |> required "gASRewards" gasRewardsDecoder
+
 
 updateQueuesDecoder : D.Decoder UpdateQueues
 updateQueuesDecoder =
     D.succeed UpdateQueues
-        |> required "mintDistribution" (updateQueueDecoder (D.oneOf [ mintDistributionV1Decoder
-                                                                    , mintDistributionV0Decoder ]))
+        |> required "mintDistribution"
+            (updateQueueDecoder
+                (D.oneOf
+                    [ mintDistributionV1Decoder
+                    , mintDistributionV0Decoder
+                    ]
+                )
+            )
         |> required "transactionFeeDistribution" (updateQueueDecoder transactionFeeDistributionDecoder)
         |> required "rootKeys" (updateQueueDecoder higherLevelKeysDecoder)
         |> required "level1Keys" (updateQueueDecoder higherLevelKeysDecoder)
@@ -222,12 +247,24 @@ updateQueuesDecoder =
         |> required "euroPerEnergy" (updateQueueDecoder relationDecoder)
         |> required "addAnonymityRevoker" (updateQueueDecoder arDecoder)
         |> required "addIdentityProvider" (updateQueueDecoder ipDecoder)
-        |> optional "poolParameters" (updateQueueDecoder (D.oneOf [ poolParametersV1Decoder
-                                                                 , poolParametersV0Decoder ]))
-           { nextSequenceNumber = 0, queue = [] }
-        |> optional "cooldownParameters" (updateQueueDecoder (D.oneOf [ cooldownParametersV1Decoder
-                                                                      , cooldownParametersV0Decoder]))
-           { nextSequenceNumber = 0, queue = [] }
+        |> optional "poolParameters"
+            (updateQueueDecoder
+                (D.oneOf
+                    [ poolParametersV1Decoder
+                    , poolParametersV0Decoder
+                    ]
+                )
+            )
+            { nextSequenceNumber = 0, queue = [] }
+        |> optional "cooldownParameters"
+            (updateQueueDecoder
+                (D.oneOf
+                    [ cooldownParametersV1Decoder
+                    , cooldownParametersV0Decoder
+                    ]
+                )
+            )
+            { nextSequenceNumber = 0, queue = [] }
         |> optional "timeParameters" (updateQueueDecoder timeParametersDecoder) { nextSequenceNumber = 0, queue = [] }
 
 
@@ -290,10 +327,12 @@ type alias BlockReward =
     , baker : T.AccountAddress
     }
 
+
 type alias PaydayFoundationReward =
     { foundationAccount : T.AccountAddress
     , developmentCharge : T.Amount
     }
+
 
 type alias PaydayAccountReward =
     { account : T.AccountAddress
@@ -301,6 +340,7 @@ type alias PaydayAccountReward =
     , bakerReward : T.Amount
     , finalizationReward : T.Amount
     }
+
 
 type alias BlockAccrueReward =
     { transactionFees : T.Amount
@@ -312,13 +352,15 @@ type alias BlockAccrueReward =
     , bakerId : T.BakerId
     }
 
+
 type alias PaydayPoolReward =
     { poolOwner : Maybe T.BakerId
     , transactionFees : T.Amount
     , bakerReward : T.Amount
     , finalizationReward : T.Amount
     }
-    
+
+
 specialEventDecoder : D.Decoder SpecialEvent
 specialEventDecoder =
     let
@@ -372,22 +414,22 @@ specialEventDecoder =
 
                 "BlockAccrueReward" ->
                     D.succeed BlockAccrueReward
-                      |> required "transactionFees" T.decodeAmount
-                      |> required "oldGASAccount" T.decodeAmount
-                      |> required "newGASAccount" T.decodeAmount
-                      |> required "bakerReward" T.decodeAmount
-                      |> required "passiveReward" T.decodeAmount
-                      |> required "foundationCharge" T.decodeAmount
-                      |> required "bakerId" D.int
-                      |> D.map SpecialEventBlockAccrueReward
+                        |> required "transactionFees" T.decodeAmount
+                        |> required "oldGASAccount" T.decodeAmount
+                        |> required "newGASAccount" T.decodeAmount
+                        |> required "bakerReward" T.decodeAmount
+                        |> required "passiveReward" T.decodeAmount
+                        |> required "foundationCharge" T.decodeAmount
+                        |> required "bakerId" D.int
+                        |> D.map SpecialEventBlockAccrueReward
 
                 "PaydayPoolReward" ->
                     D.succeed PaydayPoolReward
-                      |> required "poolOwner" (D.nullable D.int)
-                      |> required "transactionFees" T.decodeAmount
-                      |> required "bakerReward" T.decodeAmount
-                      |> required "finalizationReward" T.decodeAmount
-                      |> D.map SpecialEventPaydayPoolReward
+                        |> required "poolOwner" (D.nullable D.int)
+                        |> required "transactionFees" T.decodeAmount
+                        |> required "bakerReward" T.decodeAmount
+                        |> required "finalizationReward" T.decodeAmount
+                        |> D.map SpecialEventPaydayPoolReward
 
                 _ ->
                     D.fail """Invalid SpecialEvent tag.

--- a/src/elm/Explorer/Request.elm
+++ b/src/elm/Explorer/Request.elm
@@ -94,9 +94,9 @@ type alias ChainParametersV1 =
     , euroPerEnergy : Relation
     , poolOwnerCooldown : Int
     , delegatorCooldown : Int
-    , finalizationCommissionLPool : Float
-    , bakingCommissionLPool : Float
-    , transactionCommissiionLPool : Float
+    , passiveFinalizationCommission : Float
+    , passiveBakingCommission : Float
+    , passiveTransactionCommission : Float
     , finalizationCommissionRange : Range Float
     , bakingCommissionRange : Range Float
     , transactionCommissionRange : Range Float
@@ -184,9 +184,9 @@ chainParametersDecoderV1 =
         |> required "euroPerEnergy" relationDecoder
         |> required "poolOwnerCooldown" D.int
         |> required "delegatorCooldown" D.int
-        |> required "finalizationCommissionLPool" D.float
-        |> required "bakingCommissionLPool" D.float
-        |> required "transactionCommissionLPool" D.float
+        |> required "passiveFinalizationCommission" D.float
+        |> required "passiveBakingCommission" D.float
+        |> required "passiveTransactionCommission" D.float
         |> required "finalizationCommissionRange" (rangeDecoder D.float)
         |> required "bakingCommissionRange" (rangeDecoder D.float)
         |> required "transactionCommissionRange" (rangeDecoder D.float)
@@ -307,7 +307,7 @@ type alias BlockAccrueReward =
     , oldGASAccount : T.Amount
     , newGASAccount : T.Amount
     , bakerReward : T.Amount
-    , lPoolReward : T.Amount
+    , passiveReward : T.Amount
     , foundationCharge : T.Amount
     , bakerId : T.BakerId
     }
@@ -376,7 +376,7 @@ specialEventDecoder =
                       |> required "oldGASAccount" T.decodeAmount
                       |> required "newGASAccount" T.decodeAmount
                       |> required "bakerReward" T.decodeAmount
-                      |> required "lPoolReward" T.decodeAmount
+                      |> required "passiveReward" T.decodeAmount
                       |> required "foundationCharge" T.decodeAmount
                       |> required "bakerId" D.int
                       |> D.map SpecialEventBlockAccrueReward

--- a/src/elm/Explorer/View.elm
+++ b/src/elm/Explorer/View.elm
@@ -1174,8 +1174,7 @@ viewSpecialEvent ctx chainParameters specialEvent =
                     , content = el [ spacing 10 ] <| text "Distributed minted CCD "
                     , details =
                         let
-                            foundationMintFraction =
-                                T.subAmounts (T.amountFromInt 1) (T.addAmounts event.mintBakingReward event.mintFinalizationReward)
+                            foundationMintFraction = 1 - chainParameters.rewardParameters.mintDistribution.bakingReward - chainParameters.rewardParameters.mintDistribution.finalizationReward
 
                             mintTotal =
                                 T.sumAmounts [ event.mintPlatformDevelopmentCharge, event.mintBakingReward, event.mintFinalizationReward ]
@@ -1195,9 +1194,9 @@ viewSpecialEvent ctx chainParameters specialEvent =
                             --     ]
                             , viewDetailRow [ paragraph [] [ text "These CCD are distributed among special accounts for maintaining the blockchain and for rewarding bakers and finalizers. " ] ]
                                 [ viewBar ctx
-                                    [ { color = ctx.palette.c1, percentage = T.amountToFloat event.mintBakingReward, hint = bakingRewardAccountUpper }
-                                    , { color = ctx.palette.c2, percentage = T.amountToFloat event.mintFinalizationReward, hint = finalizationRewardAccountUpper }
-                                    , { color = ctx.palette.fg2, percentage = T.amountToFloat foundationMintFraction, hint = "Foundation" }
+                                    [ { color = ctx.palette.c1, percentage = chainParameters.rewardParameters.mintDistribution.bakingReward, hint = bakingRewardAccountUpper }
+                                    , { color = ctx.palette.c2, percentage = chainParameters.rewardParameters.mintDistribution.finalizationReward , hint = finalizationRewardAccountUpper }
+                                    , { color = ctx.palette.fg2, percentage = foundationMintFraction, hint = "Foundation" }
                                     ]
                                 ]
                             , viewDetailRow

--- a/src/elm/Explorer/View.elm
+++ b/src/elm/Explorer/View.elm
@@ -126,9 +126,16 @@ viewBlockSummary theme timezone { blockSummary, state } =
 
         specialEvents =
             -- delegation payouts to individual payouts are too numerous to be displayed
-            List.filter (\ev -> case ev of
-                                    SpecialEventPaydayAccountReward _ -> False
-                                    _ -> True) blockSummary.specialEvents
+            List.filter
+                (\ev ->
+                    case ev of
+                        SpecialEventPaydayAccountReward _ ->
+                            False
+
+                        _ ->
+                            True
+                )
+                blockSummary.specialEvents
                 |> List.map (viewSpecialEvent theme blockSummary.updates.chainParameters)
 
         finalizations =
@@ -685,7 +692,7 @@ typeDescriptionAccountTransactionType accountTransactionType =
 
         ConfigureDelegation ->
             { icon = html <| Icons.baking_bread 20, short = "Configure delegation" }
-              
+
         Malformed ->
             { icon = el [ paddingXY 6 0 ] <| text "?", short = "Serialization" }
 
@@ -940,7 +947,7 @@ rejectionToItem ctx reason =
             { content = [ text "A configure baker transaction to remove baker is passed unexpected arguments" ]
             , details = Nothing
             }
-            
+
         CommissionsNotInRangeForBaking ->
             { content = [ text "Not all baker commissions are within allowed ranges" ]
             , details = Nothing
@@ -960,12 +967,12 @@ rejectionToItem ctx reason =
             { content = [ text "Tried to add baker for an account that already has a delegator" ]
             , details = Nothing
             }
-            
+
         AlreadyADelegator ->
             { content = [ text "Tried to add baker for an account that already has a delegator" ]
             , details = Nothing
             }
-            
+
         InsufficientBalanceForDelegationStake ->
             { content = [ text "The amount on the account was insufficient to cover the proposed stake" ]
             , details = Nothing
@@ -990,6 +997,7 @@ rejectionToItem ctx reason =
             { content = [ text "The change could not be made because the delegator is in cooldown" ]
             , details = Nothing
             }
+
         NotADelegator addr ->
             { content = [ text "Account ", viewAddress ctx <| T.AddressAccount addr, text " is not a delegation account" ]
             , details = Nothing
@@ -1014,6 +1022,7 @@ rejectionToItem ctx reason =
             { content = [ text "The pool is not open to delegators." ]
             , details = Nothing
             }
+
 
 viewUpdates : Theme a -> Time.Zone -> Updates -> Element Msg
 viewUpdates theme timezone updates =
@@ -1102,7 +1111,8 @@ listUpdatePayloads queues =
         ++ mapUpdate AddIdentityProviderPayload queues.identityProvider
         ++ mapUpdate PoolParametersPayload queues.poolParameters
         ++ mapUpdate CooldownParametersPayload queues.cooldownParameters
-        ++ mapUpdate TimeParametersPayload queues.timeParameters    
+        ++ mapUpdate TimeParametersPayload queues.timeParameters
+
 
 asPercentage : Float -> String
 asPercentage n =
@@ -1257,26 +1267,46 @@ viewSpecialEvent ctx chainParameters specialEvent =
                     , content = el [ spacing 10 ] <| text "Distributed minted CCD "
                     , details =
                         let
-                            rewardParameters = case chainParameters of
-                                                   CPV0 cp -> cp.rewardParameters
-                                                   CPV1 cp -> cp.rewardParameters
-                            (mintPerSlot, bakingReward, finalizationReward) =
+                            rewardParameters =
                                 case chainParameters of
-                                    CPV0 cp -> case cp.rewardParameters.mintDistribution of
-                                                   MDV0 md -> ( Just md.mintPerSlot
-                                                              , md.bakingReward
-                                                              , md.finalizationReward)
-                                                   MDV1 md -> ( Nothing
-                                                              , md.bakingReward
-                                                              , md.finalizationReward)
-                                    CPV1 cp -> case cp.rewardParameters.mintDistribution of
-                                                   MDV0 md -> ( Just md.mintPerSlot
-                                                              , md.bakingReward
-                                                              , md.finalizationReward)
-                                                   MDV1 md -> ( Nothing
-                                                              , md.bakingReward
-                                                              , md.finalizationReward)
-                            foundationMintFraction = 1 - bakingReward - finalizationReward
+                                    CPV0 cp ->
+                                        cp.rewardParameters
+
+                                    CPV1 cp ->
+                                        cp.rewardParameters
+
+                            ( mintPerSlot, bakingReward, finalizationReward ) =
+                                case chainParameters of
+                                    CPV0 cp ->
+                                        case cp.rewardParameters.mintDistribution of
+                                            MDV0 md ->
+                                                ( Just md.mintPerSlot
+                                                , md.bakingReward
+                                                , md.finalizationReward
+                                                )
+
+                                            MDV1 md ->
+                                                ( Nothing
+                                                , md.bakingReward
+                                                , md.finalizationReward
+                                                )
+
+                                    CPV1 cp ->
+                                        case cp.rewardParameters.mintDistribution of
+                                            MDV0 md ->
+                                                ( Just md.mintPerSlot
+                                                , md.bakingReward
+                                                , md.finalizationReward
+                                                )
+
+                                            MDV1 md ->
+                                                ( Nothing
+                                                , md.bakingReward
+                                                , md.finalizationReward
+                                                )
+
+                            foundationMintFraction =
+                                1 - bakingReward - finalizationReward
 
                             mintTotal =
                                 T.sumAmounts [ event.mintPlatformDevelopmentCharge, event.mintBakingReward, event.mintFinalizationReward ]
@@ -1287,12 +1317,15 @@ viewSpecialEvent ctx chainParameters specialEvent =
                                 []
                             , viewDetailRow
                                 [ paragraph [] <|
-                                      case mintPerSlot of
-                                          Just mps -> [ text "The amount depends on the number of slots since the last block, as the total supply of CCD is increased by a factor of 1 + "
-                                                      , text <| String.fromFloat mps
-                                                      , text " in every slot."
-                                                      ]
-                                          Nothing ->  [ text "The amount depends on the number of slots since the last block." ]
+                                    case mintPerSlot of
+                                        Just mps ->
+                                            [ text "The amount depends on the number of slots since the last block, as the total supply of CCD is increased by a factor of 1 + "
+                                            , text <| String.fromFloat mps
+                                            , text " in every slot."
+                                            ]
+
+                                        Nothing ->
+                                            [ text "The amount depends on the number of slots since the last block." ]
                                 ]
                                 [ el [ centerX ] <| viewSpecialAccount ctx ctx.palette.fg1 "Minted this block" mintTotal
                                 ]
@@ -1362,9 +1395,14 @@ viewSpecialEvent ctx chainParameters specialEvent =
                             ]
                     , details =
                         let
-                            rewardParameters = case chainParameters of
-                                                   CPV0 cp -> cp.rewardParameters
-                                                   CPV1 cp -> cp.rewardParameters                            
+                            rewardParameters =
+                                case chainParameters of
+                                    CPV0 cp ->
+                                        cp.rewardParameters
+
+                                    CPV1 cp ->
+                                        cp.rewardParameters
+
                             foundationTransactionFeeBlockReward =
                                 1 - (rewardParameters.transactionFeeDistribution.baker + rewardParameters.transactionFeeDistribution.gasAccount)
 
@@ -1442,56 +1480,67 @@ viewSpecialEvent ctx chainParameters specialEvent =
                     }
 
                 SpecialEventPaydayFoundationReward event ->
-                  { tooltip = "Payday foundation reward"
-                  , icon = Icons.coin_ccd 20
-                  , content = row [ spacing 10 ]
-                              [ text <| "Rewarded ",  text <| T.amountToString event.developmentCharge
-                              , text <| " to the foundation account ", viewFoundationAccount ctx (Address event.foundationAccount)
-                              ]
-                  , details = text ""
-                  }
+                    { tooltip = "Payday foundation reward"
+                    , icon = Icons.coin_ccd 20
+                    , content =
+                        row [ spacing 10 ]
+                            [ text <| "Rewarded "
+                            , text <| T.amountToString event.developmentCharge
+                            , text <| " to the foundation account "
+                            , viewFoundationAccount ctx (Address event.foundationAccount)
+                            ]
+                    , details = text ""
+                    }
 
                 -- this case will never be triggered because PaydayAccountReward events are filtered
                 -- out of the special events list before rendering it
                 SpecialEventPaydayAccountReward _ ->
-                  { tooltip = "Payday account reward"
-                  , icon = Icons.coin_ccd 20
-                  , content = text ""
-                  , details = text ""
-                  }
+                    { tooltip = "Payday account reward"
+                    , icon = Icons.coin_ccd 20
+                    , content = text ""
+                    , details = text ""
+                    }
 
                 SpecialEventBlockAccrueReward event ->
-                  { tooltip = "Block accrue reward"
-                  , icon = Icons.coin_ccd 20
-                  , content = row [ spacing 10 ] [ text "Rewards for baking this block" ]
-                  , details = column [ width fill, spacing 30]
-                              [ viewDetailRow
-                                    [ paragraph [] [ text <| "Total fees paid for transaction in the block ", text <| T.amountToString event.transactionFees ]
-                                    , paragraph [] [ text <| "Rewarded ", text <| T.amountToString event.bakerReward, text " to baker with ID ",  text <| String.fromInt event.bakerId ]
-                                    , paragraph [] [ text <| "Rewarded ", text <| T.amountToString event.passiveReward, text " to passive delegators" ]
-                                    , paragraph [] [ text <| "Rewarded ", text <| T.amountToString event.foundationCharge, text " to the foundation" ] 
-                                    ]
-                                    []
-                              ]
-                  }
+                    { tooltip = "Block accrue reward"
+                    , icon = Icons.coin_ccd 20
+                    , content = row [ spacing 10 ] [ text "Rewards for baking this block" ]
+                    , details =
+                        column [ width fill, spacing 30 ]
+                            [ viewDetailRow
+                                [ paragraph [] [ text <| "Total fees paid for transaction in the block ", text <| T.amountToString event.transactionFees ]
+                                , paragraph [] [ text <| "Rewarded ", text <| T.amountToString event.bakerReward, text " to baker with ID ", text <| String.fromInt event.bakerId ]
+                                , paragraph [] [ text <| "Rewarded ", text <| T.amountToString event.passiveReward, text " to passive delegators" ]
+                                , paragraph [] [ text <| "Rewarded ", text <| T.amountToString event.foundationCharge, text " to the foundation" ]
+                                ]
+                                []
+                            ]
+                    }
 
                 SpecialEventPaydayPoolReward event ->
-                  { tooltip = "Payday pool reward"
-                  , icon = Icons.coin_ccd 20
-                  , content = row [ spacing 10 ] [ text <| "Rewarded"
-                                                 , text <| (case event.poolOwner of
-                                                                Just poolOwner -> "pool " ++ String.fromInt poolOwner
-                                                                Nothing -> "passive") ]
-                  , details = column [ width fill, spacing 30]
-                              [ viewDetailRow
-                                    [ paragraph [] [ text <| "Transaction fees  ", text <| T.amountToString event.transactionFees ]
-                                    , paragraph [] [ text <| "Baker reward ", text <| T.amountToString event.bakerReward ]
-                                    , paragraph [] [ text <| "Finalization reward  ", text <| T.amountToString event.finalizationReward ]
-                                    ]
-                                    []
-                              ]
-                  }
-                  
+                    { tooltip = "Payday pool reward"
+                    , icon = Icons.coin_ccd 20
+                    , content =
+                        row [ spacing 10 ]
+                            [ text <| "Rewarded"
+                            , text <|
+                                case event.poolOwner of
+                                    Just poolOwner ->
+                                        "pool " ++ String.fromInt poolOwner
+
+                                    Nothing ->
+                                        "passive"
+                            ]
+                    , details =
+                        column [ width fill, spacing 30 ]
+                            [ viewDetailRow
+                                [ paragraph [] [ text <| "Transaction fees  ", text <| T.amountToString event.transactionFees ]
+                                , paragraph [] [ text <| "Baker reward ", text <| T.amountToString event.bakerReward ]
+                                , paragraph [] [ text <| "Finalization reward  ", text <| T.amountToString event.finalizationReward ]
+                                ]
+                                []
+                            ]
+                    }
     in
     [ { content =
             row contentRowAttrs <|
@@ -2025,7 +2074,8 @@ viewTransactionEvent ctx timezone txEvent =
             }
 
         TransactionEventBakerSetOpenStatus event ->
-            { content = eventElem
+            { content =
+                eventElem
                     [ text <| "Setting open status of "
                     , viewBaker ctx event.bakerId event.account
                     , text " to "
@@ -2033,9 +2083,10 @@ viewTransactionEvent ctx timezone txEvent =
                     ]
             , details = Nothing
             }
-            
+
         TransactionEventBakerSetMetadataURL event ->
-            { content = eventElem
+            { content =
+                eventElem
                     [ text <| "Setting metadata URL of "
                     , viewBaker ctx event.bakerId event.account
                     , text " to "
@@ -2043,40 +2094,43 @@ viewTransactionEvent ctx timezone txEvent =
                     ]
             , details = Nothing
             }
-            
+
         TransactionEventBakerSetTransactionFeeCommission event ->
-            { content = [ text <| "Setting transaction fee commission for "
-                    , viewBaker ctx event.bakerId event.account
-                    , text " to "
-                    , text <| String.fromFloat event.transactionFeeCommission
-                    ]
+            { content =
+                [ text <| "Setting transaction fee commission for "
+                , viewBaker ctx event.bakerId event.account
+                , text " to "
+                , text <| String.fromFloat event.transactionFeeCommission
+                ]
             , details = Nothing
             }
-            
+
         TransactionEventBakerSetBakingRewardCommission event ->
-            { content = [ text <| "Setting baking reward commission for "
-                    , viewBaker ctx event.bakerId event.account
-                    , text " to "
-                    , text <| String.fromFloat event.bakingRewardCommission
-                    ]
+            { content =
+                [ text <| "Setting baking reward commission for "
+                , viewBaker ctx event.bakerId event.account
+                , text " to "
+                , text <| String.fromFloat event.bakingRewardCommission
+                ]
             , details = Nothing
             }
-            
+
         TransactionEventBakerSetFinalizationRewardCommission event ->
-            { content = [ text <| "Setting finalization reward commission for "
-                    , viewBaker ctx event.bakerId event.account
-                    , text " to "
-                    , text <| String.fromFloat event.finalizationRewardCommission
-                    ]
+            { content =
+                [ text <| "Setting finalization reward commission for "
+                , viewBaker ctx event.bakerId event.account
+                , text " to "
+                , text <| String.fromFloat event.finalizationRewardCommission
+                ]
             , details = Nothing
             }
-            
+
         TransactionEventContractInterrupted event ->
-            { content = eventElem
+            { content =
+                eventElem
                     [ text <| "Interrupted contract with address: "
                     , viewAsAddressContract ctx event.address
                     ]
-
             , details =
                 Just <|
                     column [ width fill ]
@@ -2096,22 +2150,24 @@ viewTransactionEvent ctx timezone txEvent =
                             ]
                         ]
             }
-            
-        TransactionEventContractResumed event  ->
-            { content = eventElem
+
+        TransactionEventContractResumed event ->
+            { content =
+                eventElem
                     [ if event.success then
-                          text <| "Resumed "
+                        text <| "Resumed "
+
                       else
-                          text <| "Not resumed "
+                        text <| "Not resumed "
                     , text <| "contract with address: "
                     , viewAsAddressContract ctx event.address
                     ]
             , details = Nothing
             }
-            
+
         TransactionEventDelegationStakeIncreased event ->
             { content =
-                  eventElem
+                eventElem
                     [ text <| "Increased stake of "
                     , viewDelegator ctx event.delegatorId event.account
                     , text " to "
@@ -2119,7 +2175,7 @@ viewTransactionEvent ctx timezone txEvent =
                     ]
             , details = Nothing
             }
-            
+
         TransactionEventDelegationStakeDecreased event ->
             { content =
                 eventElem
@@ -2130,7 +2186,7 @@ viewTransactionEvent ctx timezone txEvent =
                     ]
             , details = Nothing
             }
-            
+
         TransactionEventDelegationSetRestakeEarnings event ->
             { content =
                 eventElem
@@ -2143,56 +2199,64 @@ viewTransactionEvent ctx timezone txEvent =
                     , text <|
                         " restake earnings of "
                     , viewDelegator ctx event.delegatorId event.account
-                    ]                  
+                    ]
             , details = Nothing
             }
-            
+
         TransactionEventDelegationSetDelegationTarget event ->
             { content =
                 eventElem
                     [ text <| "Set delegation target for "
                     , viewDelegator ctx event.delegatorId event.account
                     , text <| " to "
-                    , text <| case event.delegationTarget of
-                                  Just poolId -> "pool " ++ String.fromInt poolId
-                                  Nothing -> "passive delegation"
-                    ]                                    
+                    , text <|
+                        case event.delegationTarget of
+                            Just poolId ->
+                                "pool " ++ String.fromInt poolId
+
+                            Nothing ->
+                                "passive delegation"
+                    ]
             , details = Nothing
             }
-            
+
         TransactionEventDelegationAdded event ->
             { content =
                 eventElem
                     [ text <| "Added delegator "
                     , viewDelegator ctx event.delegatorId event.account
-                    ]                  
+                    ]
             , details = Nothing
             }
-            
+
         TransactionEventDelegationRemoved event ->
             { content =
                 eventElem
                     [ text <| "Removed delegator "
                     , viewDelegator ctx event.delegatorId event.account
-                    ]                  
+                    ]
             , details = Nothing
             }
+
 
 viewEventUpdateEnqueuedDetails : Theme a -> EventUpdateEnqueued -> Element Msg
 viewEventUpdateEnqueuedDetails ctx event =
     case event.payload of
         MintDistributionPayload mintDistribution ->
             let
-                (bakingReward, finalizationReward) =
+                ( bakingReward, finalizationReward ) =
                     case mintDistribution of
-                        MDV0 md -> (md.bakingReward, md.finalizationReward)
-                        MDV1 md -> (md.bakingReward, md.finalizationReward)                                   
+                        MDV0 md ->
+                            ( md.bakingReward, md.finalizationReward )
+
+                        MDV1 md ->
+                            ( md.bakingReward, md.finalizationReward )
+
                 foundationFraction =
                     1 - bakingReward - finalizationReward
             in
             viewDetailRow [ paragraph [] [ text "Updating the parameters for CCD minting." ] ]
-                [ --el [ centerX ] <| viewHeaderBox ctx ctx.palette.fg2 "Minted pr. slot" <| text <| String.fromFloat mintDistribution.mintPerSlot
-                viewBar
+                [ viewBar
                     ctx
                     [ { color = ctx.palette.c1, percentage = bakingReward, hint = bakingRewardAccountUpper }
                     , { color = ctx.palette.c2, percentage = finalizationReward, hint = finalizationRewardAccountUpper }
@@ -2296,7 +2360,7 @@ viewEventUpdateEnqueuedDetails ctx event =
 
         TimeParametersPayload _ ->
             paragraph [] [ text "Update time parameters." ]
-              
+
 
 viewFoundationAccount : Theme a -> FoundationAccountRepresentation -> Element Msg
 viewFoundationAccount ctx repr =
@@ -2450,6 +2514,7 @@ viewBaker ctx bakerId addr =
         , text <| "(Baker: " ++ String.fromInt bakerId ++ ")"
         ]
 
+
 {-| View a delegator as "<acc> (Baker: <baker-id>)". The account is shown using `viewAddress`.
 -}
 viewDelegator : Theme a -> Int -> T.AccountAddress -> Element Msg
@@ -2458,7 +2523,8 @@ viewDelegator ctx delegatorId addr =
         [ spacing 4 ]
         [ viewAddress ctx <| T.AddressAccount addr
         , text <| "(Delegator: " ++ String.fromInt delegatorId ++ ")"
-        ]        
+        ]
+
 
 viewCredId : Theme a -> String -> Element Msg
 viewCredId ctx cred =

--- a/src/elm/Explorer/View.elm
+++ b/src/elm/Explorer/View.elm
@@ -1440,7 +1440,7 @@ viewSpecialEvent ctx chainParameters specialEvent =
                               [ viewDetailRow
                                     [ paragraph [] [ text <| "Total fees paid for transaction in the block ", text <| T.amountToString event.transactionFees ]
                                     , paragraph [] [ text <| "Rewarded ", text <| T.amountToString event.bakerReward, text " to baker with ID ",  text <| String.fromInt event.bakerId ]
-                                    , paragraph [] [ text <| "Rewarded ", text <| T.amountToString event.lPoolReward, text " to the L-Pool" ]
+                                    , paragraph [] [ text <| "Rewarded ", text <| T.amountToString event.passiveReward, text " to passive delegators" ]
                                     , paragraph [] [ text <| "Rewarded ", text <| T.amountToString event.foundationCharge, text " to the foundation" ] 
                                     ]
                                     []
@@ -2127,7 +2127,7 @@ viewTransactionEvent ctx timezone txEvent =
                     , text <| " to "
                     , text <| case event.delegationTarget of
                                   Just poolId -> "pool " ++ String.fromInt poolId
-                                  Nothing -> "L-pool"
+                                  Nothing -> "passive delegation"
                     ]                                    
             , details = Nothing
             }

--- a/src/elm/Explorer/View.elm
+++ b/src/elm/Explorer/View.elm
@@ -1369,7 +1369,10 @@ viewSpecialEvent ctx chainParameters specialEvent =
                 SpecialEventPaydayPoolReward event ->
                   { tooltip = "Payday pool reward"
                   , icon = Icons.coin_ccd 20
-                  , content = row [ spacing 10 ] [ text <| "Rewarded pool ", text <| String.fromInt event.poolOwner ]
+                  , content = row [ spacing 10 ] [ text <| "Rewarded"
+                                                 , text <| (case event.poolOwner of
+                                                                Just poolOwner -> "pool " ++ String.fromInt poolOwner
+                                                                Nothing -> "L-pool") ]
                   , details = column [ width fill, spacing 30]
                               [ viewDetailRow
                                     [ paragraph [] [ text <| "Transaction fees  ", text <| T.amountToString event.transactionFees ]

--- a/src/elm/Explorer/View.elm
+++ b/src/elm/Explorer/View.elm
@@ -945,6 +945,21 @@ rejectionToItem ctx reason =
             { content = [ text "Not all baker commissions are within allowed ranges" ]
             , details = Nothing
             }
+
+        FinalizationRewardCommissionNotInRange ->
+            { content = [ text "Finalization reward commission is not in the valid range for a baker" ]
+            , details = Nothing
+            }
+
+        BakingRewardCommissionNotInRange ->
+            { content = [ text "Baking reward commission is not in the valid range for a baker" ]
+            , details = Nothing
+            }
+
+        TransactionFeeCommissionNotInRange ->
+            { content = [ text "Tried to add baker for an account that already has a delegator" ]
+            , details = Nothing
+            }
             
         AlreadyADelegator ->
             { content = [ text "Tried to add baker for an account that already has a delegator" ]
@@ -958,6 +973,11 @@ rejectionToItem ctx reason =
 
         MissingDelegationAddParameters ->
             { content = [ text "A configure delegation transaction is missing one or more arguments in order to add a delegator" ]
+            , details = Nothing
+            }
+
+        InsufficientDelegationStake ->
+            { content = [ text "The delegation stake when adding a baker was 0." ]
             , details = Nothing
             }
 
@@ -984,9 +1004,14 @@ rejectionToItem ctx reason =
             { content = [ text "The amount would result in pool capital higher than the maximum threshold" ]
             , details = Nothing
             }
-    -- |
+
         PoolWouldBecomeOverDelegated ->
             { content = [ text "The amount would result in pool with a too high fraction of delegated capital." ]
+            , details = Nothing
+            }
+
+        PoolClosed ->
+            { content = [ text "The pool is not open to delegators." ]
             , details = Nothing
             }
 
@@ -1274,7 +1299,7 @@ viewSpecialEvent ctx chainParameters specialEvent =
                             , viewDetailRow [ paragraph [] [ text "These CCD are distributed among special accounts for maintaining the blockchain and for rewarding bakers and finalizers. " ] ]
                                 [ viewBar ctx
                                     [ { color = ctx.palette.c1, percentage = bakingReward, hint = bakingRewardAccountUpper }
-                                    , { color = ctx.palette.c2, percentage = finalizationReward , hint = finalizationRewardAccountUpper }
+                                    , { color = ctx.palette.c2, percentage = finalizationReward, hint = finalizationRewardAccountUpper }
                                     , { color = ctx.palette.fg2, percentage = foundationMintFraction, hint = "Foundation" }
                                     ]
                                 ]
@@ -1332,7 +1357,7 @@ viewSpecialEvent ctx chainParameters specialEvent =
                     , icon = Icons.coin_ccd 20
                     , content =
                         row []
-                            [ text <| "Rewarded" ++ T.amountToString event.bakerReward ++ " for baking this block to "
+                            [ text <| "Rewarded " ++ T.amountToString event.bakerReward ++ " for baking this block to "
                             , viewAddress ctx (T.AddressAccount event.baker)
                             ]
                     , details =
@@ -1419,7 +1444,10 @@ viewSpecialEvent ctx chainParameters specialEvent =
                 SpecialEventPaydayFoundationReward event ->
                   { tooltip = "Payday foundation reward"
                   , icon = Icons.coin_ccd 20
-                  , content = row [ spacing 10 ] [ text <| "Rewarded ",  text <| T.amountToString event.developmentCharge, text <| " to the foundation account ", viewFoundationAccount ctx (Address event.foundationAccount) ]
+                  , content = row [ spacing 10 ]
+                              [ text <| "Rewarded ",  text <| T.amountToString event.developmentCharge
+                              , text <| " to the foundation account ", viewFoundationAccount ctx (Address event.foundationAccount)
+                              ]
                   , details = text ""
                   }
 
@@ -2011,7 +2039,7 @@ viewTransactionEvent ctx timezone txEvent =
                     [ text <| "Setting metadata URL of "
                     , viewBaker ctx event.bakerId event.account
                     , text " to "
-                    , text event.metadataUrl
+                    , text event.metadataURL
                     ]
             , details = Nothing
             }
@@ -2020,7 +2048,7 @@ viewTransactionEvent ctx timezone txEvent =
             { content = [ text <| "Setting transaction fee commission for "
                     , viewBaker ctx event.bakerId event.account
                     , text " to "
-                    , viewRelation ctx event.transactionFeeCommission
+                    , text <| String.fromFloat event.transactionFeeCommission
                     ]
             , details = Nothing
             }
@@ -2029,7 +2057,7 @@ viewTransactionEvent ctx timezone txEvent =
             { content = [ text <| "Setting baking reward commission for "
                     , viewBaker ctx event.bakerId event.account
                     , text " to "
-                    , viewRelation ctx event.bakingRewardCommission
+                    , text <| String.fromFloat event.bakingRewardCommission
                     ]
             , details = Nothing
             }
@@ -2038,7 +2066,7 @@ viewTransactionEvent ctx timezone txEvent =
             { content = [ text <| "Setting finalization reward commission for "
                     , viewBaker ctx event.bakerId event.account
                     , text " to "
-                    , viewRelation ctx event.finalizationRewardCommission
+                    , text <| String.fromFloat event.finalizationRewardCommission
                     ]
             , details = Nothing
             }

--- a/src/elm/Explorer/View.elm
+++ b/src/elm/Explorer/View.elm
@@ -1481,7 +1481,7 @@ viewSpecialEvent ctx chainParameters specialEvent =
                   , content = row [ spacing 10 ] [ text <| "Rewarded"
                                                  , text <| (case event.poolOwner of
                                                                 Just poolOwner -> "pool " ++ String.fromInt poolOwner
-                                                                Nothing -> "L-pool") ]
+                                                                Nothing -> "passive") ]
                   , details = column [ width fill, spacing 30]
                               [ viewDetailRow
                                     [ paragraph [] [ text <| "Transaction fees  ", text <| T.amountToString event.transactionFees ]

--- a/src/elm/Transaction/Event.elm
+++ b/src/elm/Transaction/Event.elm
@@ -333,11 +333,18 @@ type UpdatePayload
     | CooldownParametersPayload CooldownParameters
     | TimeParametersPayload TimeParameters
 
-type alias MintDistribution =
-    { bakingReward : Float
+type MintDistribution = MDV0 MintDistributionV0 | MDV1 MintDistributionV1
+      
+type alias MintDistributionV0 =
+    { mintPerSlot : Float
+    , bakingReward : Float
     , finalizationReward : Float
     }
 
+type alias MintDistributionV1 =
+    { bakingReward : Float
+    , finalizationReward : Float
+    }    
 
 type alias TransactionFeeDistribution =
     { gasAccount : Float
@@ -438,25 +445,38 @@ type AnonymityRevokerInfo
 type IdentityProviderInfo
     = IpInfo ArIpInfo
 
-type alias PoolParameters =
-    { bakerStakeThreshold : T.Amount
-    , finalizationCommissionLPool : T.Amount
-    , bakingCommissionLPool : T.Amount
-    , transactionCommissionLPool : T.Amount
-    , finalizationCommissionRange : Range T.Amount
-    , bakingCommissionRange : Range T.Amount
-    , transactionCommissionRange : Range T.Amount
+
+type PoolParameters = PPV0 PoolParametersV0 | PPV1 PoolParametersV1
+
+{-| 'bakerStakeThreshold' is a single pool parameter in V0
+-}
+
+type PoolParametersV0 = PoolParametersV0 T.Amount
+      
+type alias PoolParametersV1 =
+    { finalizationCommissionLPool : Float
+    , bakingCommissionLPool : Float
+    , transactionCommissionLPool : Float
+    , finalizationCommissionRange : Range Float
+    , bakingCommissionRange : Range Float
+    , transactionCommissionRange : Range Float
     , minimumEquityCapital : T.Amount
     , capitalBound : Float
-    , leverageBound : Float
+    , leverageBound : Relation
     }
 
-type alias CooldownParameters =
-    { bakerCooldownEpochs : Int
-    , poolOwnerCooldown : Int
+type CooldownParameters = CDPV0 CooldownParametersV0 | CDPV1 CooldownParametersV1
+
+{-| 'bakerCooldownEpochs' is a single cooldown parameter in V0
+-}
+    
+type CooldownParametersV0 = CooldownParametersV0 Int
+
+type alias CooldownParametersV1 =
+    { poolOwnerCooldown : Int
     , delegatorCooldown : Int
     }
-
+    
 type alias TimeParameters =
     { rewardPeriodLength : Int
     , mintPerDay : Float
@@ -495,7 +515,8 @@ updatePayloadDecoder =
             D.field "update" <|
                 case updateType of
                     "mintDistribution" ->
-                        mintDistributionDecoder |> D.map MintDistributionPayload
+                        D.oneOf [ mintDistributionV1Decoder
+                                , mintDistributionV0Decoder ] |> D.map MintDistributionPayload
 
                     "transactionFeeDistribution" ->
                         transactionFeeDistributionDecoder |> D.map TransactionFeeDistributionPayload
@@ -530,13 +551,13 @@ updatePayloadDecoder =
                     "addIdentityProvider" ->
                         ipDecoder |> D.map AddIdentityProviderPayload
 
-                    "poolParameters" ->
-                        poolParametersDecoder |> D.map PoolParametersPayload
+                    "poolParametersCPV1" ->
+                        poolParametersV1Decoder |> D.map PoolParametersPayload
 
-                    "cooldownParameters" ->
-                        cooldownParametersDecoder |> D.map CooldownParametersPayload
+                    "cooldownParametersCPV1" ->
+                        cooldownParametersV1Decoder |> D.map CooldownParametersPayload
 
-                    "timeParameters" ->
+                    "timeParametersCPV1" ->
                         timeParametersDecoder |> D.map TimeParametersPayload
                          
                     _ ->
@@ -552,14 +573,21 @@ foundationAccountRepresentationDecoder =
         , D.map Index D.int
         ]
 
-
-mintDistributionDecoder : D.Decoder MintDistribution
-mintDistributionDecoder =
-    D.succeed MintDistribution
+mintDistributionV0Decoder : D.Decoder MintDistribution
+mintDistributionV0Decoder =
+    D.succeed MintDistributionV0
+        |> required "mintPerSlot" D.float
         |> required "bakingReward" D.float
         |> required "finalizationReward" D.float
+        |> D.map MDV0
 
-
+mintDistributionV1Decoder : D.Decoder MintDistribution
+mintDistributionV1Decoder =
+    D.succeed MintDistributionV1
+        |> required "bakingReward" D.float
+        |> required "finalizationReward" D.float           
+        |> D.map MDV1
+           
 transactionFeeDistributionDecoder : D.Decoder TransactionFeeDistribution
 transactionFeeDistributionDecoder =
     D.succeed TransactionFeeDistribution
@@ -692,32 +720,44 @@ protocolUpdateDecoder =
         |> required "specificationHash" D.string
         |> required "specificationAuxiliaryData" D.string
 
-poolParametersDecoder : D.Decoder PoolParameters
-poolParametersDecoder =
-    D.succeed PoolParameters
+poolParametersV0Decoder : D.Decoder PoolParameters
+poolParametersV0Decoder =
+    D.succeed PoolParametersV0
        |> required "minimumThresholdForBaking" T.decodeAmount
-       |> required "finalizationCommissionLPool" T.decodeAmount
-       |> required "bakingCommissionLPool" T.decodeAmount
-       |> required "transactionCommissionLPool" T.decodeAmount
-       |> required "bakingCommissionRange" (rangeDecoder T.decodeAmount)
-       |> required "transactionCommissionRange" (rangeDecoder T.decodeAmount)
-       |> required "finalizationCommissionRange" (rangeDecoder T.decodeAmount)
+       |> D.map PPV0
+           
+poolParametersV1Decoder : D.Decoder PoolParameters
+poolParametersV1Decoder =
+    D.succeed PoolParametersV1
+       |> required "finalizationCommissionLPool" D.float
+       |> required "bakingCommissionLPool" D.float
+       |> required "transactionCommissionLPool" D.float
+       |> required "bakingCommissionRange" (rangeDecoder D.float)
+       |> required "transactionCommissionRange" (rangeDecoder D.float)
+       |> required "finalizationCommissionRange" (rangeDecoder D.float)
        |> required "minimumEquityCapital" T.decodeAmount
        |> required "capitalBound" D.float
-       |> required "leverageBound" D.float
-
-cooldownParametersDecoder : D.Decoder CooldownParameters
-cooldownParametersDecoder =
-    D.succeed CooldownParameters
+       |> required "leverageBound" relationDecoder
+       |> D.map PPV1
+          
+cooldownParametersV0Decoder : D.Decoder CooldownParameters
+cooldownParametersV0Decoder =
+    D.succeed CooldownParametersV0
        |> required "bakerCooldownEpochs" D.int
+       |> D.map CDPV0
+          
+cooldownParametersV1Decoder : D.Decoder CooldownParameters
+cooldownParametersV1Decoder =
+    D.succeed CooldownParametersV1
        |> required "poolOwnerCooldown" D.int
        |> required "delegatorCooldown" D.int
-
+       |> D.map CDPV1
+          
 timeParametersDecoder : D.Decoder TimeParameters
 timeParametersDecoder =
     D.succeed TimeParameters
        |> required "rewardPeriodLength" D.int
-       |> required "mintPerDay" D.float
+       |> required "mintPerPayday" D.float
           
 {-| Convert Maybe a to a Decoder which fails if the Maybe is Nothing.
 It also takes a string for the message to fail with.
@@ -927,7 +967,7 @@ transactionEventsDecoder =
                     D.succeed EventBakerSetMetadataURL
                         |> required "bakerId" D.int
                         |> required "account" T.accountAddressDecoder
-                        |> required "metadataUrl" D.string
+                        |> required "metadataURL" D.string
                         |> D.map TransactionEventBakerSetMetadataURL
 
                 "BakerSetTransactionFeeCommission" ->
@@ -993,14 +1033,14 @@ transactionEventsDecoder =
                     D.succeed EventDelegationStakeIncreased
                         |> required "delegatorId" D.int
                         |> required "account" T.accountAddressDecoder
-                        |> required "newstake" T.decodeAmount
+                        |> required "newStake" T.decodeAmount
                         |> D.map TransactionEventDelegationStakeIncreased
 
                 "DelegationStakeDecreased" ->
                     D.succeed EventDelegationStakeDecreased
                         |> required "delegatorId" D.int
                         |> required "account" T.accountAddressDecoder
-                        |> required "newstake" T.decodeAmount
+                        |> required "newStake" T.decodeAmount
                         |> D.map TransactionEventDelegationStakeDecreased
 
                 "DelegationSetRestakeEarnings" ->
@@ -1014,7 +1054,7 @@ transactionEventsDecoder =
                     D.succeed EventDelegationSetDelegationTarget
                         |> required "delegatorId" D.int
                         |> required "account" T.accountAddressDecoder
-                        |> required "delegationTarget" (D.nullable D.int)
+                        |> required "delegationTarget" T.delegationTargetDecoder
                         |> D.map TransactionEventDelegationSetDelegationTarget
 
                 "DelegationAdded" ->

--- a/src/elm/Transaction/Event.elm
+++ b/src/elm/Transaction/Event.elm
@@ -454,9 +454,9 @@ type PoolParameters = PPV0 PoolParametersV0 | PPV1 PoolParametersV1
 type PoolParametersV0 = PoolParametersV0 T.Amount
       
 type alias PoolParametersV1 =
-    { finalizationCommissionLPool : Float
-    , bakingCommissionLPool : Float
-    , transactionCommissionLPool : Float
+    { passiveFinalizationCommission : Float
+    , passiveBakingCommission : Float
+    , passiveTransactionCommission : Float
     , finalizationCommissionRange : Range Float
     , bakingCommissionRange : Range Float
     , transactionCommissionRange : Range Float

--- a/src/elm/Transaction/Event.elm
+++ b/src/elm/Transaction/Event.elm
@@ -205,25 +205,25 @@ type alias EventBakerSetOpenStatus =
 type alias EventBakerSetMetadataURL =
     { bakerId : Int
     , account : T.AccountAddress
-    , metadataUrl : String
+    , metadataURL : String
     }
 
 type alias EventBakerSetTransactionFeeCommission =
     { bakerId : Int
     , account : T.AccountAddress
-    , transactionFeeCommission : Relation
+    , transactionFeeCommission : Float
     }
     
 type alias EventBakerSetBakingRewardCommission =
     { bakerId : Int
     , account : T.AccountAddress
-    , bakingRewardCommission : Relation
+    , bakingRewardCommission : Float
     }
     
 type alias EventBakerSetFinalizationRewardCommission =
     { bakerId : Int
     , account : T.AccountAddress
-    , finalizationRewardCommission : Relation        
+    , finalizationRewardCommission : Float        
     }
 
 -- Contracts
@@ -383,7 +383,7 @@ type alias Authorizations =
     , protocol : Authorization
     , paramGASRewards : Authorization
     , emergency : Authorization
-    , bakerStakeThreshold : Authorization
+    , poolParameters : Authorization
     , keys : List AuthorizationKey
     }
 
@@ -469,7 +469,7 @@ type CooldownParameters = CDPV0 CooldownParametersV0 | CDPV1 CooldownParametersV
 
 {-| 'bakerCooldownEpochs' is a single cooldown parameter in V0
 -}
-    
+
 type CooldownParametersV0 = CooldownParametersV0 Int
 
 type alias CooldownParametersV1 =
@@ -496,6 +496,9 @@ relationDecoder =
     D.succeed Relation
         |> required "denominator" D.int
         |> required "numerator" D.int
+
+{-| A range that includes both endpoints.
+ -}
 
 type alias Range a =
     { min : a
@@ -664,7 +667,7 @@ authorizationsDecoder =
         |> required "protocol" authorizationDecoder
         |> required "paramGASRewards" authorizationDecoder
         |> required "emergency" authorizationDecoder
-        |> required "bakerStakeThreshold" authorizationDecoder
+        |> required "poolParameters" authorizationDecoder
         |> required "keys" (D.list authorizationKeyDecoder)
 
 
@@ -729,9 +732,9 @@ poolParametersV0Decoder =
 poolParametersV1Decoder : D.Decoder PoolParameters
 poolParametersV1Decoder =
     D.succeed PoolParametersV1
-       |> required "finalizationCommissionLPool" D.float
-       |> required "bakingCommissionLPool" D.float
-       |> required "transactionCommissionLPool" D.float
+       |> required "passiveFinalizationCommission" D.float
+       |> required "passiveBakingCommission" D.float
+       |> required "passiveTransactionCommission" D.float
        |> required "bakingCommissionRange" (rangeDecoder D.float)
        |> required "transactionCommissionRange" (rangeDecoder D.float)
        |> required "finalizationCommissionRange" (rangeDecoder D.float)
@@ -974,21 +977,21 @@ transactionEventsDecoder =
                     D.succeed EventBakerSetTransactionFeeCommission
                         |> required "bakerId" D.int
                         |> required "account" T.accountAddressDecoder
-                        |> required "transactionFeeCommission" relationDecoder
+                        |> required "transactionFeeCommission" D.float
                         |> D.map TransactionEventBakerSetTransactionFeeCommission
 
                 "BakerSetBakingRewardCommission" ->
                     D.succeed EventBakerSetBakingRewardCommission
                         |> required "bakerId" D.int
                         |> required "account" T.accountAddressDecoder
-                        |> required "bakingRewardCommission" relationDecoder
+                        |> required "bakingRewardCommission" D.float
                         |> D.map TransactionEventBakerSetBakingRewardCommission
                     
                 "BakerSetFinalizationRewardCommission" ->
                     D.succeed EventBakerSetFinalizationRewardCommission
                         |> required "bakerId" D.int
                         |> required "account" T.accountAddressDecoder
-                        |> required "finalizationRewardCommission" relationDecoder
+                        |> required "finalizationRewardCommission" D.float
                         |> D.map TransactionEventBakerSetFinalizationRewardCommission
                            
                 -- Contracts

--- a/src/elm/Transaction/Event.elm
+++ b/src/elm/Transaction/Event.elm
@@ -196,11 +196,13 @@ type alias EventBakerKeysUpdated =
     , aggregationKey : String
     }
 
+
 type alias EventBakerSetOpenStatus =
     { bakerId : Int
     , account : T.AccountAddress
-    , openStatus : String        
+    , openStatus : String
     }
+
 
 type alias EventBakerSetMetadataURL =
     { bakerId : Int
@@ -208,23 +210,28 @@ type alias EventBakerSetMetadataURL =
     , metadataURL : String
     }
 
+
 type alias EventBakerSetTransactionFeeCommission =
     { bakerId : Int
     , account : T.AccountAddress
     , transactionFeeCommission : Float
     }
-    
+
+
 type alias EventBakerSetBakingRewardCommission =
     { bakerId : Int
     , account : T.AccountAddress
     , bakingRewardCommission : Float
     }
-    
+
+
 type alias EventBakerSetFinalizationRewardCommission =
     { bakerId : Int
     , account : T.AccountAddress
-    , finalizationRewardCommission : Float        
+    , finalizationRewardCommission : Float
     }
+
+
 
 -- Contracts
 
@@ -251,55 +258,68 @@ type alias EventContractUpdated =
     , events : List T.ContractEvent
     }
 
+
 type alias EventContractInterrupted =
     { address : T.ContractAddress
     , events : List T.ContractEvent
     }
+
 
 type alias EventContractResumed =
     { address : T.ContractAddress
     , success : Bool
     }
 
+
 type alias EventDataRegistered =
     { data : ArbitraryBytes
     }
 
+
+
 -- Delegation
+
 
 type alias EventDelegationStakeIncreased =
     { delegatorId : Int
     , account : T.AccountAddress
     , newStake : T.Amount
     }
-    
+
+
 type alias EventDelegationStakeDecreased =
     { delegatorId : Int
     , account : T.AccountAddress
     , newStake : T.Amount
     }
-    
+
+
 type alias EventDelegationSetRestakeEarnings =
     { delegatorId : Int
     , account : T.AccountAddress
     , restakeEarnings : Bool
     }
-    
+
+
 type alias EventDelegationSetDelegationTarget =
     { delegatorId : Int
     , account : T.AccountAddress
     , delegationTarget : Maybe Int
     }
-    
+
+
 type alias EventDelegationAdded =
     { delegatorId : Int
     , account : T.AccountAddress
     }
-    
+
+
 type alias EventDelegationRemoved =
     { delegatorId : Int
     , account : T.AccountAddress
     }
+
+
 
 -- Core
 
@@ -333,18 +353,24 @@ type UpdatePayload
     | CooldownParametersPayload CooldownParameters
     | TimeParametersPayload TimeParameters
 
-type MintDistribution = MDV0 MintDistributionV0 | MDV1 MintDistributionV1
-      
+
+type MintDistribution
+    = MDV0 MintDistributionV0
+    | MDV1 MintDistributionV1
+
+
 type alias MintDistributionV0 =
     { mintPerSlot : Float
     , bakingReward : Float
     , finalizationReward : Float
     }
 
+
 type alias MintDistributionV1 =
     { bakingReward : Float
     , finalizationReward : Float
-    }    
+    }
+
 
 type alias TransactionFeeDistribution =
     { gasAccount : Float
@@ -446,13 +472,17 @@ type IdentityProviderInfo
     = IpInfo ArIpInfo
 
 
-type PoolParameters = PPV0 PoolParametersV0 | PPV1 PoolParametersV1
+type PoolParameters
+    = PPV0 PoolParametersV0
+    | PPV1 PoolParametersV1
+
 
 {-| 'bakerStakeThreshold' is a single pool parameter in V0
 -}
+type PoolParametersV0
+    = PoolParametersV0 T.Amount
 
-type PoolParametersV0 = PoolParametersV0 T.Amount
-      
+
 type alias PoolParametersV1 =
     { passiveFinalizationCommission : Float
     , passiveBakingCommission : Float
@@ -465,23 +495,31 @@ type alias PoolParametersV1 =
     , leverageBound : Relation
     }
 
-type CooldownParameters = CDPV0 CooldownParametersV0 | CDPV1 CooldownParametersV1
+
+type CooldownParameters
+    = CDPV0 CooldownParametersV0
+    | CDPV1 CooldownParametersV1
+
 
 {-| 'bakerCooldownEpochs' is a single cooldown parameter in V0
 -}
+type CooldownParametersV0
+    = CooldownParametersV0 Int
 
-type CooldownParametersV0 = CooldownParametersV0 Int
 
 type alias CooldownParametersV1 =
     { poolOwnerCooldown : Int
     , delegatorCooldown : Int
     }
-    
+
+
 type alias TimeParameters =
     { rewardPeriodLength : Int
     , mintPerDay : Float
     }
-    
+
+
+
 -- Errors
 
 
@@ -497,19 +535,21 @@ relationDecoder =
         |> required "denominator" D.int
         |> required "numerator" D.int
 
-{-| A range that includes both endpoints.
- -}
 
+{-| A range that includes both endpoints.
+-}
 type alias Range a =
     { min : a
     , max : a
     }
+
 
 rangeDecoder : D.Decoder a -> D.Decoder (Range a)
 rangeDecoder dec =
     D.succeed Range
         |> required "min" dec
         |> required "max" dec
+
 
 updatePayloadDecoder : D.Decoder UpdatePayload
 updatePayloadDecoder =
@@ -518,8 +558,11 @@ updatePayloadDecoder =
             D.field "update" <|
                 case updateType of
                     "mintDistribution" ->
-                        D.oneOf [ mintDistributionV1Decoder
-                                , mintDistributionV0Decoder ] |> D.map MintDistributionPayload
+                        D.oneOf
+                            [ mintDistributionV1Decoder
+                            , mintDistributionV0Decoder
+                            ]
+                            |> D.map MintDistributionPayload
 
                     "transactionFeeDistribution" ->
                         transactionFeeDistributionDecoder |> D.map TransactionFeeDistributionPayload
@@ -562,7 +605,7 @@ updatePayloadDecoder =
 
                     "timeParametersCPV1" ->
                         timeParametersDecoder |> D.map TimeParametersPayload
-                         
+
                     _ ->
                         D.fail "Unknown update type"
     in
@@ -576,6 +619,7 @@ foundationAccountRepresentationDecoder =
         , D.map Index D.int
         ]
 
+
 mintDistributionV0Decoder : D.Decoder MintDistribution
 mintDistributionV0Decoder =
     D.succeed MintDistributionV0
@@ -584,13 +628,15 @@ mintDistributionV0Decoder =
         |> required "finalizationReward" D.float
         |> D.map MDV0
 
+
 mintDistributionV1Decoder : D.Decoder MintDistribution
 mintDistributionV1Decoder =
     D.succeed MintDistributionV1
         |> required "bakingReward" D.float
-        |> required "finalizationReward" D.float           
+        |> required "finalizationReward" D.float
         |> D.map MDV1
-           
+
+
 transactionFeeDistributionDecoder : D.Decoder TransactionFeeDistribution
 transactionFeeDistributionDecoder =
     D.succeed TransactionFeeDistribution
@@ -723,45 +769,51 @@ protocolUpdateDecoder =
         |> required "specificationHash" D.string
         |> required "specificationAuxiliaryData" D.string
 
+
 poolParametersV0Decoder : D.Decoder PoolParameters
 poolParametersV0Decoder =
     D.succeed PoolParametersV0
-       |> required "minimumThresholdForBaking" T.decodeAmount
-       |> D.map PPV0
-           
+        |> required "minimumThresholdForBaking" T.decodeAmount
+        |> D.map PPV0
+
+
 poolParametersV1Decoder : D.Decoder PoolParameters
 poolParametersV1Decoder =
     D.succeed PoolParametersV1
-       |> required "passiveFinalizationCommission" D.float
-       |> required "passiveBakingCommission" D.float
-       |> required "passiveTransactionCommission" D.float
-       |> required "bakingCommissionRange" (rangeDecoder D.float)
-       |> required "transactionCommissionRange" (rangeDecoder D.float)
-       |> required "finalizationCommissionRange" (rangeDecoder D.float)
-       |> required "minimumEquityCapital" T.decodeAmount
-       |> required "capitalBound" D.float
-       |> required "leverageBound" relationDecoder
-       |> D.map PPV1
-          
+        |> required "passiveFinalizationCommission" D.float
+        |> required "passiveBakingCommission" D.float
+        |> required "passiveTransactionCommission" D.float
+        |> required "bakingCommissionRange" (rangeDecoder D.float)
+        |> required "transactionCommissionRange" (rangeDecoder D.float)
+        |> required "finalizationCommissionRange" (rangeDecoder D.float)
+        |> required "minimumEquityCapital" T.decodeAmount
+        |> required "capitalBound" D.float
+        |> required "leverageBound" relationDecoder
+        |> D.map PPV1
+
+
 cooldownParametersV0Decoder : D.Decoder CooldownParameters
 cooldownParametersV0Decoder =
     D.succeed CooldownParametersV0
-       |> required "bakerCooldownEpochs" D.int
-       |> D.map CDPV0
-          
+        |> required "bakerCooldownEpochs" D.int
+        |> D.map CDPV0
+
+
 cooldownParametersV1Decoder : D.Decoder CooldownParameters
 cooldownParametersV1Decoder =
     D.succeed CooldownParametersV1
-       |> required "poolOwnerCooldown" D.int
-       |> required "delegatorCooldown" D.int
-       |> D.map CDPV1
-          
+        |> required "poolOwnerCooldown" D.int
+        |> required "delegatorCooldown" D.int
+        |> D.map CDPV1
+
+
 timeParametersDecoder : D.Decoder TimeParameters
 timeParametersDecoder =
     D.succeed TimeParameters
-       |> required "rewardPeriodLength" D.int
-       |> required "mintPerPayday" D.float
-          
+        |> required "rewardPeriodLength" D.int
+        |> required "mintPerPayday" D.float
+
+
 {-| Convert Maybe a to a Decoder which fails if the Maybe is Nothing.
 It also takes a string for the message to fail with.
 -}
@@ -986,14 +1038,14 @@ transactionEventsDecoder =
                         |> required "account" T.accountAddressDecoder
                         |> required "bakingRewardCommission" D.float
                         |> D.map TransactionEventBakerSetBakingRewardCommission
-                    
+
                 "BakerSetFinalizationRewardCommission" ->
                     D.succeed EventBakerSetFinalizationRewardCommission
                         |> required "bakerId" D.int
                         |> required "account" T.accountAddressDecoder
                         |> required "finalizationRewardCommission" D.float
                         |> D.map TransactionEventBakerSetFinalizationRewardCommission
-                           
+
                 -- Contracts
                 "ModuleDeployed" ->
                     D.succeed EventModuleDeployed
@@ -1030,7 +1082,7 @@ transactionEventsDecoder =
                         |> required "address" T.contractAddressDecoder
                         |> required "success" D.bool
                         |> D.map TransactionEventContractResumed
-                           
+
                 -- Delegation
                 "DelegationStakeIncreased" ->
                     D.succeed EventDelegationStakeIncreased
@@ -1070,7 +1122,7 @@ transactionEventsDecoder =
                     D.succeed EventDelegationRemoved
                         |> required "delegatorId" D.int
                         |> required "account" T.accountAddressDecoder
-                        |> D.map TransactionEventDelegationRemoved       
+                        |> D.map TransactionEventDelegationRemoved
 
                 -- Core
                 "UpdateEnqueued" ->

--- a/src/elm/Transaction/Summary.elm
+++ b/src/elm/Transaction/Summary.elm
@@ -28,7 +28,7 @@ type TransactionSummaryType
     | UpdateTransaction UpdateType
 
 
-{-| Reason for transaction rejected
+{-| Supported transaction types
 
 Must be in sync with the constructor names of `Payload` found in
 <https://github.com/Concordium/concordium-base/blob/main/haskell-src/Concordium/Types/Execution.hs>
@@ -56,6 +56,8 @@ type AccountTransactionType
     | TransferWithMemo
     | EncryptedAmountTransferWithMemo
     | TransferWithScheduleAndMemo
+    | ConfigureBaker
+    | ConfigureDelegation
     | Malformed
 
 
@@ -286,6 +288,12 @@ accountTransactionTypeDecoder =
 
                 "registerData" ->
                     D.succeed RegisterData
+
+                "configureBaker" ->
+                    D.succeed ConfigureBaker
+
+                "configureDelegation" ->
+                    D.succeed ConfigureDelegation
 
                 _ ->
                     D.fail <| "Unknown AccountTransaction type: " ++ tipe

--- a/src/elm/Transaction/Summary.elm
+++ b/src/elm/Transaction/Summary.elm
@@ -96,8 +96,14 @@ type UpdateType
       -- ^Update the minimum stake that a baker needs to have to be able to bake
     | UpdateAddAnonymityRevoker
       -- ^Add a new anonymity revoker
-    | UpdateAddIdentityProvider -- ^Add a new identity provider
-
+    | UpdateAddIdentityProvider
+      -- ^Add a new identity provider
+    | UpdatePoolParameters
+      -- ^Update for pool parameters (previously baker stake threshold)
+    | UpdateCooldownParameters
+    -- ^Update for cooldown parameters, but not used by chain parameter version 0
+    | UpdateTimeParameters
+    -- ^Update for time parameters, but not used by chain parameter version 0
 
 type TransactionResult
     = TransactionAccepted (List TransactionEvent)
@@ -372,6 +378,15 @@ updateTypeDecoder =
                     "updateAddIdentityProvider" ->
                         D.succeed UpdateAddIdentityProvider
 
+                    "updatePoolParameters" ->
+                        D.succeed UpdatePoolParameters
+
+                    "updateCooldownParameters" ->
+                        D.succeed UpdateCooldownParameters
+
+                    "updateTimeParameters" ->
+                        D.succeed UpdateTimeParameters
+                 
                     _ ->
                         D.fail <| "Unknown UpdateType type: " ++ str
             )

--- a/src/elm/Transaction/Summary.elm
+++ b/src/elm/Transaction/Summary.elm
@@ -99,9 +99,10 @@ type UpdateType
     | UpdatePoolParameters
       -- ^Update for pool parameters (previously baker stake threshold)
     | UpdateCooldownParameters
-    -- ^Update for cooldown parameters, but not used by chain parameter version 0
+      -- ^Update for cooldown parameters, but not used by chain parameter version 0
     | UpdateTimeParameters
-    -- ^Update for time parameters, but not used by chain parameter version 0
+      -- ^Update for time parameters, but not used by chain parameter version 0
+
 
 type TransactionResult
     = TransactionAccepted (List TransactionEvent)
@@ -183,40 +184,41 @@ type RejectReason
     | NotAllowedToReceiveEncrypted
       -- |The account is not allowed to send encrypted transfers (or transfer from/to public to/from encrypted)
     | NotAllowedToHandleEncrypted
-    -- |A configure baker transaction is missing one or more arguments in order to add a baker.
+      -- |A configure baker transaction is missing one or more arguments in order to add a baker.
     | MissingBakerAddParameters
-    -- |A configure baker transaction to remove baker is passed unexpected arguments.
+      -- |A configure baker transaction to remove baker is passed unexpected arguments.
     | UnexpectedBakerRemoveParameters
-    -- |Not all baker commissions are within allowed ranges
+      -- |Not all baker commissions are within allowed ranges
     | CommissionsNotInRangeForBaking
-    -- |Finalization reward commission is not in the valid range for a baker
+      -- |Finalization reward commission is not in the valid range for a baker
     | FinalizationRewardCommissionNotInRange
-    -- |Baking reward commission is not in the valid range for a baker
+      -- |Baking reward commission is not in the valid range for a baker
     | BakingRewardCommissionNotInRange
-    -- |Transaction fee commission is not in the valid range for a baker
+      -- |Transaction fee commission is not in the valid range for a baker
     | TransactionFeeCommissionNotInRange
-    -- |Tried to add baker for an account that already has a delegator
+      -- |Tried to add baker for an account that already has a delegator
     | AlreadyADelegator
-    -- |The amount on the account was insufficient to cover the proposed stake
+      -- |The amount on the account was insufficient to cover the proposed stake
     | InsufficientBalanceForDelegationStake
-    -- |A configure delegation transaction is missing one or more arguments in order to add a delegator.
+      -- |A configure delegation transaction is missing one or more arguments in order to add a delegator.
     | MissingDelegationAddParameters
-    -- |A configure delegation transaction to remove delegation is passed unexpected arguments.
+      -- |A configure delegation transaction to remove delegation is passed unexpected arguments.
     | UnexpectedDelegationRemoveParameters
-    -- |The delegation stake when adding a baker was 0.
+      -- |The delegation stake when adding a baker was 0.
     | InsufficientDelegationStake
-    -- |The change could not be made because the delegator is in cooldown
+      -- |The change could not be made because the delegator is in cooldown
     | DelegatorInCooldown
-    -- |Account is not a delegation account
+      -- |Account is not a delegation account
     | NotADelegator T.AccountAddress
-    -- |Delegation target is not a baker
+      -- |Delegation target is not a baker
     | DelegationTargetNotABaker T.BakerId
-    -- |The amount would result in pool capital higher than the maximum threshold
+      -- |The amount would result in pool capital higher than the maximum threshold
     | StakeOverMaximumThresholdForPool
-    -- |The amount would result in pool with a too high fraction of delegated capital.
-    | PoolWouldBecomeOverDelegated    
-    -- |The pool is not open to delegators.
+      -- |The amount would result in pool with a too high fraction of delegated capital.
+    | PoolWouldBecomeOverDelegated
+      -- |The pool is not open to delegators.
     | PoolClosed
+
 
 type alias RejectReasonRejectedInit =
     { rejectReason : Int
@@ -391,7 +393,7 @@ updateTypeDecoder =
 
                     "updateTimeParameters" ->
                         D.succeed UpdateTimeParameters
-                 
+
                     _ ->
                         D.fail <| "Unknown UpdateType type: " ++ str
             )
@@ -600,10 +602,10 @@ rejectReasonDecoder =
 
                 "MissingBakerAddParameters" ->
                     D.succeed MissingBakerAddParameters
-                        
+
                 "UnexpectedBakerRemoveParameters" ->
                     D.succeed UnexpectedBakerRemoveParameters
-                        
+
                 "CommissionsNotInRangeForBaking" ->
                     D.succeed CommissionsNotInRangeForBaking
 
@@ -615,25 +617,25 @@ rejectReasonDecoder =
 
                 "TransactionFeeCommissionNotInRange" ->
                     D.succeed TransactionFeeCommissionNotInRange
-                        
+
                 "AlreadyADelegator" ->
                     D.succeed AlreadyADelegator
-                        
+
                 "InsufficientBalanceForDelegationStake" ->
                     D.succeed InsufficientBalanceForDelegationStake
-                        
+
                 "MissingDelegationAddParameters" ->
                     D.succeed MissingDelegationAddParameters
-                        
+
                 "UnexpectedDelegationRemoveParameters" ->
                     D.succeed UnexpectedDelegationRemoveParameters
 
                 "InsufficientDelegationStake" ->
                     D.succeed InsufficientDelegationStake
-                        
+
                 "DelegatorInCooldown" ->
                     D.succeed DelegatorInCooldown
-                        
+
                 "NotADelegator" ->
                     D.map NotADelegator <|
                         D.field "contents" T.accountAddressDecoder
@@ -641,10 +643,10 @@ rejectReasonDecoder =
                 "DelegationTargetNotABaker" ->
                     D.map DelegationTargetNotABaker <|
                         D.field "contents" D.int
-                    
+
                 "StakeOverMaximumThresholdForPool" ->
                     D.succeed StakeOverMaximumThresholdForPool
-                    
+
                 "PoolWouldBecomeOverDelegated" ->
                     D.succeed PoolWouldBecomeOverDelegated
 

--- a/src/elm/Transaction/Summary.elm
+++ b/src/elm/Transaction/Summary.elm
@@ -179,7 +179,30 @@ type RejectReason
     | NotAllowedToReceiveEncrypted
       -- |The account is not allowed to send encrypted transfers (or transfer from/to public to/from encrypted)
     | NotAllowedToHandleEncrypted
-
+    -- |A configure baker transaction is missing one or more arguments in order to add a baker.
+    | MissingBakerAddParameters
+    -- |A configure baker transaction to remove baker is passed unexpected arguments.
+    | UnexpectedBakerRemoveParameters
+    -- |Not all baker commissions are within allowed ranges
+    | CommissionsNotInRangeForBaking
+    -- |Tried to add baker for an account that already has a delegator
+    | AlreadyADelegator
+    -- |The amount on the account was insufficient to cover the proposed stake
+    | InsufficientBalanceForDelegationStake
+    -- |A configure delegation transaction is missing one or more arguments in order to add a delegator.
+    | MissingDelegationAddParameters
+    -- |A configure delegation transaction to remove delegation is passed unexpected arguments.
+    | UnexpectedDelegationRemoveParameters
+    -- |The change could not be made because the delegator is in cooldown
+    | DelegatorInCooldown
+    -- |Account is not a delegation account
+    | NotADelegator T.AccountAddress
+    -- |Delegation target is not a baker
+    | DelegationTargetNotABaker T.BakerId
+    -- |The amount would result in pool capital higher than the maximum threshold
+    | StakeOverMaximumThresholdForPool
+    -- |The amount would result in pool with a too high fraction of delegated capital.
+    | PoolWouldBecomeOverDelegated    
 
 type alias RejectReasonRejectedInit =
     { rejectReason : Int
@@ -554,6 +577,44 @@ rejectReasonDecoder =
 
                 "NotAllowedToHandleEncrypted" ->
                     D.succeed NotAllowedToHandleEncrypted
+
+                "MissingBakerAddParameters" ->
+                    D.succeed MissingBakerAddParameters
+                        
+                "UnexpectedBakerRemoveParameters" ->
+                    D.succeed UnexpectedBakerRemoveParameters
+                        
+                "CommissionsNotInRangeForBaking" ->
+                    D.succeed CommissionsNotInRangeForBaking
+                        
+                "AlreadyADelegator" ->
+                    D.succeed AlreadyADelegator
+                        
+                "InsufficientBalanceForDelegationStake" ->
+                    D.succeed InsufficientBalanceForDelegationStake
+                        
+                "MissingDelegationAddParameters" ->
+                    D.succeed MissingDelegationAddParameters
+                        
+                "UnexpectedDelegationRemoveParameters" ->
+                    D.succeed UnexpectedDelegationRemoveParameters
+                        
+                "DelegatorInCooldown" ->
+                    D.succeed DelegatorInCooldown
+                        
+                "NotADelegator" ->
+                    D.map NotADelegator <|
+                        D.field "contents" T.accountAddressDecoder
+
+                "DelegationTargetNotABaker" ->
+                    D.map DelegationTargetNotABaker <|
+                        D.field "contents" D.int
+                    
+                "StakeOverMaximumThresholdForPool" ->
+                    D.succeed StakeOverMaximumThresholdForPool
+                    
+                "PoolWouldBecomeOverDelegated" ->
+                    D.succeed PoolWouldBecomeOverDelegated
 
                 _ ->
                     D.fail <| "Unknown RejectReason: " ++ tag

--- a/src/elm/Transaction/Summary.elm
+++ b/src/elm/Transaction/Summary.elm
@@ -92,8 +92,6 @@ type UpdateType
       -- ^Update the distribution of transaction fees
     | UpdateGASRewards
       -- ^Update the GAS rewards
-    | UpdateBakerStakeThreshold
-      -- ^Update the minimum stake that a baker needs to have to be able to bake
     | UpdateAddAnonymityRevoker
       -- ^Add a new anonymity revoker
     | UpdateAddIdentityProvider
@@ -191,6 +189,12 @@ type RejectReason
     | UnexpectedBakerRemoveParameters
     -- |Not all baker commissions are within allowed ranges
     | CommissionsNotInRangeForBaking
+    -- |Finalization reward commission is not in the valid range for a baker
+    | FinalizationRewardCommissionNotInRange
+    -- |Baking reward commission is not in the valid range for a baker
+    | BakingRewardCommissionNotInRange
+    -- |Transaction fee commission is not in the valid range for a baker
+    | TransactionFeeCommissionNotInRange
     -- |Tried to add baker for an account that already has a delegator
     | AlreadyADelegator
     -- |The amount on the account was insufficient to cover the proposed stake
@@ -199,6 +203,8 @@ type RejectReason
     | MissingDelegationAddParameters
     -- |A configure delegation transaction to remove delegation is passed unexpected arguments.
     | UnexpectedDelegationRemoveParameters
+    -- |The delegation stake when adding a baker was 0.
+    | InsufficientDelegationStake
     -- |The change could not be made because the delegator is in cooldown
     | DelegatorInCooldown
     -- |Account is not a delegation account
@@ -209,6 +215,8 @@ type RejectReason
     | StakeOverMaximumThresholdForPool
     -- |The amount would result in pool with a too high fraction of delegated capital.
     | PoolWouldBecomeOverDelegated    
+    -- |The pool is not open to delegators.
+    | PoolClosed
 
 type alias RejectReasonRejectedInit =
     { rejectReason : Int
@@ -368,9 +376,6 @@ updateTypeDecoder =
 
                     "updateGASRewards" ->
                         D.succeed UpdateGASRewards
-
-                    "updateBakerStakeThreshold" ->
-                        D.succeed UpdateBakerStakeThreshold
 
                     "updateAddAnonymityRevoker" ->
                         D.succeed UpdateAddAnonymityRevoker
@@ -601,6 +606,15 @@ rejectReasonDecoder =
                         
                 "CommissionsNotInRangeForBaking" ->
                     D.succeed CommissionsNotInRangeForBaking
+
+                "FinalizationRewardCommissionNotInRange" ->
+                    D.succeed FinalizationRewardCommissionNotInRange
+
+                "BakingRewardCommissionNotInRange" ->
+                    D.succeed BakingRewardCommissionNotInRange
+
+                "TransactionFeeCommissionNotInRange" ->
+                    D.succeed TransactionFeeCommissionNotInRange
                         
                 "AlreadyADelegator" ->
                     D.succeed AlreadyADelegator
@@ -613,6 +627,9 @@ rejectReasonDecoder =
                         
                 "UnexpectedDelegationRemoveParameters" ->
                     D.succeed UnexpectedDelegationRemoveParameters
+
+                "InsufficientDelegationStake" ->
+                    D.succeed InsufficientDelegationStake
                         
                 "DelegatorInCooldown" ->
                     D.succeed DelegatorInCooldown

--- a/src/elm/Types.elm
+++ b/src/elm/Types.elm
@@ -237,13 +237,17 @@ amountToInt (MicroCCD bigInt) =
         |> String.toInt
         |> Maybe.withDefault 0
 
+
 {-| Convert amount to Float.
 -}
 amountToFloat : Amount -> Float
 amountToFloat (MicroCCD bigInt) =
     (BigInt.toString bigInt
         |> String.toFloat
-        |> Maybe.withDefault 0) / (toFloat (10 ^ fracPartLength))
+        |> Maybe.withDefault 0
+    )
+        / toFloat (10 ^ fracPartLength)
+
 
 {-| Divides two amounts a and b as (a / b).
 Unsafe: Since it is converting the amounts to a JS number, the result is imprecise
@@ -356,13 +360,21 @@ contractReceiveNameDecoder =
                         D.fail "Invalid receive function name"
             )
 
-delegationTargetDecoder: D.Decoder (Maybe Int)
+
+delegationTargetDecoder : D.Decoder (Maybe Int)
 delegationTargetDecoder =
-    (D.field "delegateType" D.string)
-        |> D.andThen (\dt -> case dt of
-                                 "Baker" -> D.succeed Just |> required "bakerId" D.int 
-                                 _ -> D.succeed Nothing)
-           
+    D.field "delegateType" D.string
+        |> D.andThen
+            (\dt ->
+                case dt of
+                    "Baker" ->
+                        D.succeed Just |> required "bakerId" D.int
+
+                    _ ->
+                        D.succeed Nothing
+            )
+
+
 type alias BakerId =
     Int
 

--- a/src/elm/Types.elm
+++ b/src/elm/Types.elm
@@ -356,7 +356,13 @@ contractReceiveNameDecoder =
                         D.fail "Invalid receive function name"
             )
 
-
+delegationTargetDecoder: D.Decoder (Maybe Int)
+delegationTargetDecoder =
+    (D.field "delegateType" D.string)
+        |> D.andThen (\dt -> case dt of
+                                 "Baker" -> D.succeed Just |> required "bakerId" D.int 
+                                 _ -> D.succeed Nothing)
+           
 type alias BakerId =
     Int
 

--- a/src/elm/Types.elm
+++ b/src/elm/Types.elm
@@ -237,6 +237,13 @@ amountToInt (MicroCCD bigInt) =
         |> String.toInt
         |> Maybe.withDefault 0
 
+{-| Convert amount to Float.
+-}
+amountToFloat : Amount -> Float
+amountToFloat (MicroCCD bigInt) =
+    (BigInt.toString bigInt
+        |> String.toFloat
+        |> Maybe.withDefault 0) / (toFloat (10 ^ fracPartLength))
 
 {-| Divides two amounts a and b as (a / b).
 Unsafe: Since it is converting the amounts to a JS number, the result is imprecise


### PR DESCRIPTION
## Purpose

These changes permit the dashboard to parse correctly the `blockSummary` API response V1, which accompanies the protocol V4. They include the display of `ConfigureBaker` and `ConfigureDelegation` transactions and of payday events, such as block rewards to pools and the foundation. 

Closes #91.
Closes #89  

## Changes

The `ChainParameters` and `AccountTransactionType` types were updated to match their counterparts on the node side, together with the JSON decoders in Elm.

As the protocol V4 doesn't have a notion of per-slot minting, the dashboard doesn't display it anymore.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
