### PR TITLE
Added handling PoolClosed to rejectReasonDecoder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "concordium-dashboard",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Concordium Network Dashboard",
   "main": "dashboard-backend.js",
   "engines": {

--- a/src/elm/Transaction/Summary.elm
+++ b/src/elm/Transaction/Summary.elm
@@ -650,6 +650,9 @@ rejectReasonDecoder =
                 "PoolWouldBecomeOverDelegated" ->
                     D.succeed PoolWouldBecomeOverDelegated
 
+                "PoolClosed" ->
+                    D.succeed PoolClosed
+                        
                 _ ->
                     D.fail <| "Unknown RejectReason: " ++ tag
     in


### PR DESCRIPTION
## Purpose

JSON decoder fails because there was no handling of the "pool closed" reject reason. 

## Changes

Adds the `PoolClosed` case in `rejectReasonDecoder`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
