### PR TITLE
Renamed "Client" row to "Node"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Correctly display the effective time of updates with immediate effect.
 - Display the ConfigureBaker and ConfigureDelegation transactions
 - Display pool, passive delegation and foundation block rewards
+- Corrected the node version column label in the node list
 
 ## [1.0.4]
 

--- a/src/elm/Network/NodesTable.elm
+++ b/src/elm/Network/NodesTable.elm
@@ -104,7 +104,7 @@ nodesTable ctx sortMode nodes =
                         \node ->
                             text <| asTimeAgoDuration node.uptime
                   }
-                , { header = sortableHeader ctx sortMode SortClient "Client"
+                , { header = sortableHeader ctx sortMode SortClient "Node"
                   , width = fill
                   , view =
                         \node ->


### PR DESCRIPTION
## Purpose

Closes #93

## Changes

The node version column label in the node list is now "Node".

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [X] I accept the above linked CLA.
