### PR TITLE
Enabled paging in special events view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Display pool, passive delegation and foundation block rewards
 - Display transactions without associated events
 - Corrected the node version column label in the node list
+- Enabled special events paging in the block summary
 
 ## [1.0.4]
 

--- a/src/elm/Explorer/View.elm
+++ b/src/elm/Explorer/View.elm
@@ -178,7 +178,7 @@ viewBlockSummary theme timezone { blockSummary, state } =
                     , cost = none
                     , txHash = none
                     }
-            , column [ width fill, spacing 5 ] <| viewSummaryItem theme (List.concat specialEvents ++ finalizations) state.specialEventWithDetailsOpen (Display << ToggleSpecialEventDetails) initialTransactionEventPaging (\_ -> Nop)
+            , column [ width fill, spacing 5 ] <| viewSummaryItems theme (List.singleton (List.concat specialEvents ++ finalizations)) state.specialEventWithDetailsOpen (\t e -> Display <| Explorer.ToggleSpecialEventDetails t e) state.specialEventPagingModel (\i -> Display << SpecialEventPaging i)
             ]
         , section
             [ titleWithSubtitle theme "Updates" "Updates queued at the time of this block"


### PR DESCRIPTION
## Purpose

Closes #99

## Changes

Added a paging model for special events, which makes the already existing "next" button work.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
