### PR TITLE
Handle smart contract upgraded event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-# Unreleased changes
+## Unreleased changes
+
+## [1.1.0]
+
+### Added
 
 - Add ability to display the new smart contract "Upgraded" event.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased changes
 
+- Add ability to display the new smart contract "Upgraded" event.
+
 ## [1.0.10]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "concordium-dashboard",
-  "version": "1.0.2",
+  "version": "1.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "concordium-dashboard",
-      "version": "1.0.2",
+      "version": "1.0.10",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.15.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "concordium-dashboard",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "concordium-dashboard",
-      "version": "1.0.10",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.15.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "concordium-dashboard",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Concordium Network Dashboard",
   "main": "dashboard-backend.js",
   "engines": {

--- a/src/elm/Explorer/View.elm
+++ b/src/elm/Explorer/View.elm
@@ -2537,7 +2537,7 @@ viewAddress ctx addr =
                 ]
 
 {-| View a smart contract module reference. The first 8 characters are displayed,
-    and there are a tooltip hover effect and copy on click effects.
+    and there is a tooltip hover effect and copy on click effects.
 -}
 viewModuleRef : Theme a -> T.ModuleRef -> Element Msg
 viewModuleRef ctx ref =

--- a/src/elm/Explorer/View.elm
+++ b/src/elm/Explorer/View.elm
@@ -2184,6 +2184,20 @@ viewTransactionEvent ctx timezone txEvent =
             , details = Nothing
             }
 
+        TransactionEventContractUpgraded event ->
+            { content =
+                eventElem
+                    [ text "Upgraded "
+                    , text <| "contract with address: "
+                    , viewAsAddressContract ctx event.address
+                    , text <| "from "
+                    , viewModuleRef ctx event.from
+                    , text <| " to "
+                    , viewModuleRef ctx event.to
+                    ]
+            , details = Nothing
+            }
+
         TransactionEventDelegationStakeIncreased event ->
             { content =
                 eventElem
@@ -2521,6 +2535,20 @@ viewAddress ctx addr =
                 [ el [] (html <| Icons.smart_contract 18)
                 , text <| T.contractAddressToString address
                 ]
+
+{-| View a smart contract module reference. The first 8 characters are displayed,
+    and there are a tooltip hover effect and copy on click effects.
+-}
+viewModuleRef : Theme a -> T.ModuleRef -> Element Msg
+viewModuleRef ctx ref =
+    row [ spacing 4
+        , stringTooltipAboveWithCopy ctx ref
+        , pointer
+        , onClick (CopyToClipboard ref)
+        ]
+        [ el [] (html <| Icons.smart_contract 18)
+        , text (String.left 8 ref)
+        ]
 
 
 {-| View a baker as "<acc> (Baker: <baker-id>)". The account is shown using `viewAddress`.

--- a/src/elm/Transaction/Event.elm
+++ b/src/elm/Transaction/Event.elm
@@ -46,6 +46,7 @@ type TransactionEvent
     | TransactionEventContractUpdated EventContractUpdated
     | TransactionEventContractInterrupted EventContractInterrupted
     | TransactionEventContractResumed EventContractResumed
+    | TransactionEventContractUpgraded EventContractUpgraded
       -- Delegation
     | TransactionEventDelegationStakeIncreased EventDelegationStakeIncreased
     | TransactionEventDelegationStakeDecreased EventDelegationStakeDecreased
@@ -264,12 +265,16 @@ type alias EventContractInterrupted =
     , events : List T.ContractEvent
     }
 
-
 type alias EventContractResumed =
     { address : T.ContractAddress
     , success : Bool
     }
 
+type alias EventContractUpgraded =
+    { address : T.ContractAddress
+    , from : T.ModuleRef
+    , to : T.ModuleRef
+    }
 
 type alias EventDataRegistered =
     { data : ArbitraryBytes
@@ -1084,6 +1089,13 @@ transactionEventsDecoder =
                         |> required "address" T.contractAddressDecoder
                         |> required "success" D.bool
                         |> D.map TransactionEventContractResumed
+
+                "Upgraded" ->
+                    D.succeed EventContractUpgraded
+                        |> required "address" T.contractAddressDecoder
+                        |> required "from" D.string
+                        |> required "to" D.string
+                        |> D.map TransactionEventContractUpgraded
 
                 -- Delegation
                 "DelegationStakeIncreased" ->


### PR DESCRIPTION
## Purpose

Handle the smart contract upgraded event

## Changes

- Handle new event case
- Add a function for displaying module references similarly to how we display addresses. I.e. with a tooltip on hover and the ability to copy on click.
  - I just used the smart contract symbol for this, but perhaps we should use something else? Any suggestions?
  
<img width="1050" alt="image" src="https://user-images.githubusercontent.com/5469652/199267122-556001b2-79b8-4cd6-8d41-93ada2e7b7ac.png">

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.