### PR TITLE
Update network dashboard for protocol 6.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased changes
 
+## [1.3.0]
+
+- Remove blockSlot from expected response of block info, making the dashboard
+  work with protocol version 6.
+
 ## [1.2.0]
 
 ## Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "concordium-dashboard",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Concordium Network Dashboard",
   "main": "dashboard-backend.js",
   "engines": {

--- a/src/elm/Api.elm
+++ b/src/elm/Api.elm
@@ -104,7 +104,6 @@ type alias BlockInfo =
     , blockReceiveTime : Posix
     , transactionCount : Int
     , transactionEnergyCost : Int
-    , blockSlot : Int
     , blockLastFinalized : String
     , blockSlotTime : Posix
     , blockHeight : Int
@@ -135,7 +134,6 @@ blockInfoDecoder =
         |> required "blockReceiveTime" Iso8601.decoder
         |> required "transactionCount" D.int
         |> required "transactionEnergyCost" D.int
-        |> required "blockSlot" D.int
         |> required "blockLastFinalized" D.string
         |> required "blockSlotTime" Iso8601.decoder
         |> required "blockHeight" D.int


### PR DESCRIPTION
## Purpose

blockSlot is not used by the network dashboard, but it was still expected when parsing. This removes it to make the network dashboard work with  protocol 6.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
