### PR TITLE
Fix chain display when a lot of nodes are behind.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased changes
 
+## 1.3.2
+
+- Fix chain display when a lot of nodes are left behind in case of a protocol update.
+
 ## 1.3.1
 
 - Remove finalization proof gas parameter from expected parameters since they

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "concordium-dashboard",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Concordium Network Dashboard",
   "main": "dashboard-backend.js",
   "engines": {

--- a/src/elm/Api.elm
+++ b/src/elm/Api.elm
@@ -75,6 +75,7 @@ type alias ConsensusStatus =
     { bestBlock : String
     , genesisTime : Posix
     , epochDuration : Int
+    , currentEraGenesisBlock: String
     }
 
 
@@ -84,6 +85,7 @@ consensusStatusDecoder =
         |> required "bestBlock" D.string
         |> required "genesisTime" Iso8601.decoder
         |> required "epochDuration" D.int
+        |> required "currentEraGenesisBlock" D.string
 
 
 

--- a/src/elm/Network.elm
+++ b/src/elm/Network.elm
@@ -391,6 +391,14 @@ allowedNodeVersion : { ctx | minVersionIncludedInStats : String } -> { a | clien
 allowedNodeVersion ctx node =
     node.client >= ctx.minVersionIncludedInStats
 
+{-| Filter out nodes whose last finalized block height is strictly less than provided.
+    If the minimum height is not provided the function acts as the identity function.
+-}
+filterNodesByHeight : Maybe Int -> List {node | finalizedBlockHeight: Int} -> List {node | finalizedBlockHeight: Int}
+filterNodesByHeight minHeight =
+    case minHeight of
+        Nothing -> \x -> x
+        Just h -> List.filter (\n -> n.finalizedBlockHeight >= h)
 
 {-| For the given node attribute, finds majority value across all nodes
 and returns that, or the default if unknown.


### PR DESCRIPTION
## Purpose

Fix chain display.

## Changes

The chain display will now only consider nodes whose reported last finalized block is above the current era genesis block.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.